### PR TITLE
Regla accounts_passwords_pam_tally2_lock_account creada con check y fix

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_lock_account/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_lock_account/ansible/shared.yml
@@ -1,0 +1,50 @@
+# platform = multi_platform_sle
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+- name: Insert a the new rule before an existing rule in common-auth
+  pamd:
+    name: common-auth
+    type: auth
+    control: required
+    module_path: pam_env.so
+    new_type: auth
+    new_control: required
+    new_module_path: pam_tally2.so
+    module_arguments: 'onerr=fail audit silent deny=5 unlock_time=900'
+    state: before
+
+- name: Replace all module arguments in the existing rule in common-auth
+  pamd:
+    name: common-auth
+    type: auth
+    control: required
+    module_path: pam_tally2.so
+    module_arguments: 'onerr=fail audit silent deny=5 unlock_time=900'
+    state: updated
+
+
+
+- name: Insert a the new rule before an existing rule in common-account
+  pamd:
+    name: common-account
+    type: account
+    control: required
+    module_path: pam_unix.so
+    new_type: account
+    new_control: required
+    new_module_path: pam_tally2.so
+    state: before
+
+- name: Replace all module arguments in the existing rule in common-account
+  pamd:
+    name: common-account
+    type: account
+    control: required
+    module_path: pam_tally2.so
+    module_arguments: ''
+    state: updated
+
+

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_lock_account/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_lock_account/oval/shared.xml
@@ -1,0 +1,50 @@
+<def-group>
+  <definition class="compliance" id="accounts_passwords_pam_tally2_lock_account" version="1">
+    <metadata>
+      <title>accounts_passwords_pam_tally2_lock_account</title>
+      <affected family="unix">
+        <platform>multi_platform_sle</platform>
+      </affected>
+      <description>
+        accounts_passwords_pam_tally2_lock_account
+      </description>
+    </metadata>
+
+<!--visual separator-->
+
+    <criteria operator="AND">
+      <criterion comment="Check if the line auth required pam_tally2.so onerr=fail audit silent deny=5 unlock_time=900 exists in common-auth" test_ref="test_accounts_passwords_pam_tally2_lock_account_common_auth_pattern" />
+      <criterion comment="Check if the line account required pam_tally2.so exists in common-account" test_ref="test_accounts_passwords_pam_tally2_lock_account_common_account_pattern" />
+    </criteria>
+  </definition>
+
+<!--visual separator-->
+
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+  comment="Check if the line auth required pam_tally2.so onerr=fail audit silent deny=5 unlock_time=900 exists in common-auth"
+  id="test_accounts_passwords_pam_tally2_lock_account_common_auth_pattern" version="1">
+    <ind:object object_ref="object_accounts_passwords_pam_tally2_lock_account_common_auth_pattern" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+  comment="Check if the line account required pam_tally2.so exists in common-account"
+  id="test_accounts_passwords_pam_tally2_lock_account_common_account_pattern" version="1">
+    <ind:object object_ref="object_accounts_passwords_pam_tally2_lock_account_common_account_pattern" />
+  </ind:textfilecontent54_test>
+
+<!--visual separator-->
+
+    <ind:textfilecontent54_object comment="Check if the line auth required pam_tally2.so onerr=fail audit silent deny=5 unlock_time=900 exists in common-auth" id="object_accounts_passwords_pam_tally2_lock_account_common_auth_pattern" version="1">
+      <ind:filepath>/etc/pam.d/common-auth</ind:filepath>
+      <ind:pattern operation="pattern match">^auth.*required.*pam_tally2.so.*((?=.*onerr=fail).(?=.*audit).(?=.*silent).(?=.*deny=5).(?=.*unlock_time=900)).*$</ind:pattern>
+      <ind:instance datatype="int" operation="equals">1</ind:instance>
+    </ind:textfilecontent54_object>
+
+
+    <ind:textfilecontent54_object comment="Check if the line account required pam_tally2.so exists in common-account" id="object_accounts_passwords_pam_tally2_lock_account_common_account_pattern" version="1">
+      <ind:filepath>/etc/pam.d/common-account</ind:filepath>
+      <ind:pattern operation="pattern match">^account.*required.*pam_tally2.so$</ind:pattern>
+      <ind:instance datatype="int" operation="equals">1</ind:instance>
+    </ind:textfilecontent54_object>
+
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_lock_account/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_lock_account/rule.yml
@@ -1,0 +1,20 @@
+documentation_complete: true
+
+prodtype: fedora,multi_platform_sle,ol7,ol8,rhel6,rhel7,rhel8,rhv4,sle11,sle12
+
+title: 'Set account lock settings for failed password attempts using pam_tally2.so'
+
+description: |-
+    Set account lock settings for failed password attempts using pam_tally2.so.
+
+rationale: |-
+    Set account lock settings for failed password attempts using pam_tally2.so.
+
+severity: medium
+
+ocil_clause: 'Account lock is not configured'
+
+ocil: |-
+    Ensure the failed password attempt policy is configured correctly.
+
+platform: pam

--- a/reglasrisi
+++ b/reglasrisi
@@ -210,9 +210,11 @@ audit_rules_privileged_commands			-No se aplican correcciones
 sshd_use_approved_macs				-Funciona pero el check da error???
 rsyslog_nolisten				-No existe fix
 rsyslog_files_permissions			-Existe fix pero no funciona
-accounts_passwords_pam_faillock_interval	-En suse lo de pam va distinto a rhel
-accounts_passwords_pam_faillock_deny
-accounts_passwords_pam_faillock_unlock_time
+
+x-accounts_passwords_pam_faillock_interval	-En suse lo de pam va distinto a rhel(todas las reglas accounts_passwords_pam_faillock* han sido integradas en una sola regla para suse: accounts_passwords_pam_tally2_lock_account)
+x-accounts_passwords_pam_faillock_deny
+x-accounts_passwords_pam_faillock_unlock_time
+
 accounts_password_pam_unix_remember
 no_empty_passwords				-El fix no funciona?
 set_password_hashing_algorithm_systemauth	-El fix(bash) no funciona?
@@ -259,6 +261,7 @@ x-no_forward_files
 x-no_rhosts_files
 x-accounts_root_path_dirs_ownership
 x-package_libwrap0_installed
+x-accounts_passwords_pam_tally2_lock_account
 
 PENDIENTES DE APROBACION FINAL
 
@@ -270,6 +273,7 @@ accounts_root_path_dirs_ownership		-regla, check y fix
 package_libwrap0_installed			-Regla, check y fix
 sshd_set_max_auth_tries				-Check y fix
 bios_enable_execution_restrictions		-Check
+accounts_passwords_pam_tally2_lock_account	-Regla, check y fix
 
 EJEMPLOS INTERESANTES OVAL
 

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -1,9 +1,0 @@
-documentation_complete: true
-
-title: 'prueba'
-
-description: |- 
-    Write the profile description here
-
-selections:
-    - accounts_passwords_pam_tally2_lock_account

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -6,4 +6,4 @@ description: |-
     Write the profile description here
 
 selections:
-    - bios_enable_execution_restrictions
+    - accounts_passwords_pam_tally2_lock_account


### PR DESCRIPTION
#### Description:

- Regla accounts_passwords_pam_tally2_lock_account creada con check y fix

#### Rationale:

- Esta regla configura el bloqueo de cuenta por intentos fallidos de inicio de sesión gracias al modulo pam_tally2 tal como se especifica en la guía de seguridad de suse. 
