### PR TITLE
Regla accounts_password_pam_pwhistory_remember_suse creada con check …

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_suse/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_suse/ansible/shared.yml
@@ -1,0 +1,26 @@
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_rhv,multi_platform_sle
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = medium
+
+- name: Insert a the new rule before an existing rule in common-password
+  pamd:
+    name: common-password
+    type: password
+    control: required
+    module_path: pam_unix.so
+    new_type: password
+    new_control: required
+    new_module_path: pam_pwhistory.so
+    module_arguments: 'remember=5'
+    state: before
+
+- name: Replace all module arguments in the existing rule in common-password
+  pamd:
+    name: common-password
+    type: password
+    control: required
+    module_path: pam_pwhistory.so
+    module_arguments: 'remember=5'
+    state: updated

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_suse/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_suse/oval/shared.xml
@@ -1,0 +1,28 @@
+<def-group>
+  <definition class="compliance" id="accounts_password_pam_pwhistory_remember_suse" version="2">
+    <metadata>
+      <title>Limit Password Reuse</title>
+      <affected family="unix">
+        <platform>multi_platform_sle</platform>
+      </affected>
+      <description>The passwords to remember should be set correctly.</description>
+    </metadata>
+    <criteria comment="remember parameter of pam_pwhistory.so is set correctly">
+      <criterion comment="remember parameter of pam_pwhistory.so is set correctly" test_ref="test_accounts_password_pam_pwhistory_remember_suse" />
+    </criteria>
+  </definition>
+
+
+  <!-- Check the pam_pwhistory.so remember case -->
+  <ind:textfilecontent54_test id="test_accounts_password_pam_pwhistory_remember_suse" check="all" check_existence="all_exist"
+  comment="Test if remember attribute of pam_pwhistory.so is set correctly in /etc/pam.d/common-password" version="1">
+    <ind:object object_ref="object_accounts_password_pam_pwhistory_remember_suse" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_accounts_password_pam_pwhistory_remember_suse" version="1">
+    <ind:filepath>/etc/pam.d/common-password</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*password\s+(?:(?:requisite)|(?:required))\s+pam_pwhistory\.so.*remember=5.*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_suse/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_suse/rule.yml
@@ -1,0 +1,60 @@
+documentation_complete: true
+
+prodtype: sle11,sle12
+
+title: 'Limit Password Reuse'
+
+description: |-
+    Do not allow users to reuse recent passwords. This can be
+    accomplished by using the <tt>remember</tt> option for the <tt>pam_pwhistory</tt>
+    or <tt>pam_pwhistory</tt> PAM modules.
+    <br /><br />
+    In the file <tt>/etc/pam.d/common-password</tt>, append <tt>remember=<sub idref="var_password_pam_pwhistory_remember" /></tt>
+    to the line which refers to the <tt>pam_unix.so</tt> or <tt>pam_pwhistory.so</tt>module, as shown below:
+    <ul>
+    <li>for the <tt>pam_unix.so</tt> case:
+    <pre>password sufficient pam_unix.so <i>...existing_options...</i> remember=<sub idref="var_password_pam_unix_remember" /></pre>
+    </li>
+    <li>for the <tt>pam_pwhistory.so</tt> case:
+    <pre>password requisite pam_pwhistory.so <i>...existing_options...</i> remember=<sub idref="var_password_pam_unix_remember" /></pre>
+    </li>
+    </ul>
+    The DoD STIG requirement is 5 passwords.
+
+rationale: 'Preventing re-use of previous passwords helps ensure that a compromised password is not re-used by a user.'
+
+severity: medium
+
+identifiers:
+    cce@rhel6: 26741-9
+    cce@rhel7: 82030-8
+    cce@rhel8: 80666-1
+
+references:
+    stigid@rhel6: "000274"
+    srg@rhel6: SRG-OS-000077
+    cis: 5.3.3
+    cjis: 5.6.2.1.1
+    cui: 3.5.8
+    disa: "200"
+    nist: IA-5(f),IA-5(1)(e)
+    nist-csf: PR.AC-1,PR.AC-6,PR.AC-7
+    pcidss: Req-8.2.5
+    srg: SRG-OS-000077-GPOS-00045
+    vmmsrg: SRG-OS-000077-VMM-000440
+    stigid@rhel7: "010270"
+    isa-62443-2013: 'SR 1.1,SR 1.10,SR 1.2,SR 1.3,SR 1.4,SR 1.5,SR 1.7,SR 1.8,SR 1.9,SR 2.1'
+    isa-62443-2009: 4.3.3.2.2,4.3.3.5.1,4.3.3.5.2,4.3.3.6.1,4.3.3.6.2,4.3.3.6.3,4.3.3.6.4,4.3.3.6.5,4.3.3.6.6,4.3.3.6.7,4.3.3.6.8,4.3.3.6.9,4.3.3.7.2,4.3.3.7.4
+    cobit5: DSS05.04,DSS05.05,DSS05.07,DSS05.10,DSS06.03,DSS06.10
+    iso27001-2013: A.18.1.4,A.7.1.1,A.9.2.1,A.9.2.2,A.9.2.3,A.9.2.4,A.9.2.6,A.9.3.1,A.9.4.2,A.9.4.3
+    cis-csc: 1,12,15,16,5
+
+ocil_clause: 'the value of remember is not set equal to or greater than the expected setting'
+
+ocil: |-
+    To verify the password reuse setting is compliant, run the following command:
+    <pre>$ grep remember /etc/pam.d/common-password</pre>
+    The output should show the following at the end of the line:
+    <pre>remember=<sub idref="var_password_pam_pwhistory_remember" /></pre>
+
+platform: pam

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -1,9 +1,0 @@
-documentation_complete: true
-
-title: 'prueba'
-
-description: |- 
-    Write the profile description here
-
-selections:
-    - accounts_password_pam_pwhistory_remember_suse

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -6,4 +6,4 @@ description: |-
     Write the profile description here
 
 selections:
-    - bios_enable_execution_restrictions
+    - accounts_password_pam_pwhistory_remember_suse


### PR DESCRIPTION
…y fix

#### Description:

- Regla para para asegurarse de que los usuarios no estén reciclando contraseñas recientes en SUSE.

#### Rationale:

- Esta regla es una adaptación de la regla ya existente "accounts_password_pam_unix_remember" debido a que esta ultima no era apta para SUSE. 
