### PR TITLE
Regla no_empty_passwords_suse creada con check y fix

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_suse/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_suse/ansible/shared.yml
@@ -1,0 +1,17 @@
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_rhv,multi_platform_sle
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = medium
+- name: "Prevent Log In to Accounts With Empty Password - common-auth"
+  replace:
+    dest: /etc/pam.d/common-auth
+    follow: yes
+    regexp: 'nullok'
+
+- name: "Prevent Log In to Accounts With Empty Password - common-auth"
+  replace:
+    dest: /etc/pam.d/common-auth
+    follow: yes
+    regexp: 'nullok'
+

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_suse/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_suse/oval/shared.xml
@@ -1,0 +1,22 @@
+<def-group>
+  <definition class="compliance" id="no_empty_passwords_suse" version="1">
+    <metadata>
+      <title>No nullok Option in /etc/pam.d/common-auth</title>
+      <affected family="unix">
+        <platform>multi_platform_sle</platform>
+      </affected>
+      <description>The file /etc/pam.d/common-auth should not contain the nullok option</description>
+    </metadata>
+    <criteria>
+      <criterion comment="make sure the nullok option is not used in /etc/pam.d/common-auth" test_ref="test_no_empty_passwords_suse" />
+    </criteria>
+  </definition>
+  <ind:textfilecontent54_test check="all" check_existence="none_exist" comment="make sure nullok is not used in /etc/pam.d/common-auth" id="test_no_empty_passwords_suse" version="1">
+    <ind:object object_ref="object_no_empty_passwords_suse" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_no_empty_passwords_suse" version="1">
+    <ind:filepath>/etc/pam.d/common-auth</ind:filepath>
+    <ind:pattern operation="pattern match">^[^#]*\bnullok\b.*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_suse/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_suse/rule.yml
@@ -1,0 +1,52 @@
+documentation_complete: true
+
+prodtype: multi_platform_sle,sle11,sle12
+
+title: 'Prevent Login to Accounts With Empty Password'
+
+description: |-
+    If an account is configured for password authentication
+    but does not have an assigned password, it may be possible to log
+    into the account without authentication. Remove any instances of the <tt>nullok</tt>
+    option in <tt>/etc/pam.d/common-auth</tt> to
+    prevent logins with empty passwords.
+
+rationale: |-
+    If an account has an empty password, anyone could log in and
+    run commands with the privileges of that account. Accounts with
+    empty passwords should never be used in operational environments.
+
+severity: high
+
+identifiers:
+    cce@rhel6: 27038-9
+    cce@rhel7: 27286-4
+    cce@rhel8: 80841-0
+
+references:
+    stigid@rhel6: "000030"
+    srg@rhel6: SRG-OS-999999
+    cjis: 5.5.2
+    cui: '3.1.1,3.1.5'
+    disa: "366"
+    hipaa: 164.308(a)(1)(ii)(B),164.308(a)(7)(i),164.308(a)(7)(ii)(A),164.310(a)(1),164.310(a)(2)(i),164.310(a)(2)(ii),164.310(a)(2)(iii),164.310(b),164.310(c),164.310(d)(1),164.310(d)(2)(iii)
+    nist: AC-6,IA-5(b),IA-5(c),IA-5(1)(a)
+    nist-csf: PR.AC-1,PR.AC-4,PR.AC-6,PR.AC-7,PR.DS-5
+    ospp: FIA_AFL.1
+    pcidss: Req-8.2.3
+    srg: SRG-OS-000480-GPOS-00227
+    stigid@rhel7: "010290"
+    isa-62443-2013: 'SR 1.1,SR 1.10,SR 1.2,SR 1.3,SR 1.4,SR 1.5,SR 1.7,SR 1.8,SR 1.9,SR 2.1,SR 5.2'
+    isa-62443-2009: 4.3.3.2.2,4.3.3.5.1,4.3.3.5.2,4.3.3.6.1,4.3.3.6.2,4.3.3.6.3,4.3.3.6.4,4.3.3.6.5,4.3.3.6.6,4.3.3.6.7,4.3.3.6.8,4.3.3.6.9,4.3.3.7.2,4.3.3.7.3,4.3.3.7.4
+    cobit5: APO01.06,DSS05.04,DSS05.05,DSS05.07,DSS05.10,DSS06.02,DSS06.03,DSS06.10
+    iso27001-2013: A.10.1.1,A.11.1.4,A.11.1.5,A.11.2.1,A.13.1.1,A.13.1.3,A.13.2.1,A.13.2.3,A.13.2.4,A.14.1.2,A.14.1.3,A.18.1.4,A.6.1.2,A.7.1.1,A.7.1.2,A.7.3.1,A.8.2.2,A.8.2.3,A.9.1.1,A.9.1.2,A.9.2.1,A.9.2.2,A.9.2.3,A.9.2.4,A.9.2.6,A.9.3.1,A.9.4.1,A.9.4.2,A.9.4.3,A.9.4.4,A.9.4.5
+    cis-csc: 1,12,13,14,15,16,18,3,5
+
+ocil_clause: 'NULL passwords can be used'
+
+ocil: |-
+    To verify that null passwords cannot be used, run the following command:
+    <pre>$ grep nullok /etc/pam.d/common-auth</pre>
+    If this produces any output, it may be possible to log into accounts
+    with empty passwords. Remove any instances of the <tt>nullok</tt> option to
+    prevent logins with empty passwords.

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -6,4 +6,4 @@ description: |-
     Write the profile description here
 
 selections:
-    - bios_enable_execution_restrictions
+    - no_empty_passwords_suse

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -1,9 +1,0 @@
-documentation_complete: true
-
-title: 'prueba'
-
-description: |- 
-    Write the profile description here
-
-selections:
-    - no_empty_passwords_suse


### PR DESCRIPTION
#### Description:

- Regla para impedir que los usuarios puedan iniciar sesión sin contraseña.

#### Rationale:

- Regla que elimina cualquier instancia de nullok en common-auth, por lo que se impiden los inicios de sesión sin proporcionar una contraseña valida.
