### PR TITLE
Regla set_password_hashing_algorithm_systemauth_suse creada con check…

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth_suse/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth_suse/ansible/shared.yml
@@ -1,0 +1,16 @@
+# platform = multi_platform_sle
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+- name: Replace all module arguments in the existing rule in common-auth
+  pamd:
+    name: common-password
+    type: password
+    control: required
+    module_path: pam_unix.so
+    module_arguments: 'sha512'
+    state: args_present
+
+

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth_suse/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth_suse/oval/shared.xml
@@ -1,0 +1,25 @@
+<def-group>
+  <definition class="compliance" id="set_password_hashing_algorithm_systemauth_suse" version="1">
+    <metadata>
+      <title>Set Password Hashing Algorithm in /etc/pam.d/common-password</title>
+      <affected family="unix">
+        <platform>multi_platform_sle</platform>
+      </affected>
+      <description>The password hashing algorithm should be set correctly in /etc/pam.d/common-password.</description>
+    </metadata>
+    <criteria operator="AND">
+      <criterion test_ref="test_pam_unix_sha512_suse" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="at_least_one_exists" comment="check /etc/pam.d/common-password for correct settings" id="test_pam_unix_sha512_suse" version="1">
+    <ind:object object_ref="object_pam_unix_sha512_suse" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object comment="check /etc/pam.d/common-password for correct settings" id="object_pam_unix_sha512_suse" version="1">
+    <ind:filepath>/etc/pam.d/common-password</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*password[\s]+(?:(?:required)|(?:sufficient))[\s]+pam_unix\.so[\s]+.*sha512.*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth_suse/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth_suse/rule.yml
@@ -1,0 +1,69 @@
+documentation_complete: true
+
+prodtype: sle11,sle12
+
+title: "Set PAM's Password Hashing Algorithm"
+
+description: |-
+    The PAM system service can be configured to only store encrypted
+    representations of passwords. In <tt>/etc/pam.d/common-password</tt>, the
+    <tt>password</tt> section of the file controls which PAM modules execute
+    during a password change. Set the <tt>pam_unix.so</tt> module in the
+    <tt>password</tt> section to include the argument <tt>sha512</tt>, as shown
+    below:
+    <br />
+    <pre>password    sufficient    pam_unix.so sha512 <i>other arguments...</i></pre>
+    <br />
+    This will help ensure when local users change their passwords, hashes for
+    the new passwords will be generated using the SHA-512 algorithm. This is
+    the default.
+
+rationale: |-
+    Passwords need to be protected at all times, and encryption is the standard
+    method for protecting passwords. If passwords are not encrypted, they can
+    be plainly read (i.e., clear text) and easily compromised. Passwords that
+    are encrypted with a weak algorithm are no more protected than if they are
+    kepy in plain text.
+    <br /><br />
+    This setting ensures user and group account administration utilities are
+    configured to store only encrypted representations of passwords.
+    Additionally, the <tt>crypt_style</tt> configuration option ensures the use
+    of a strong hashing algorithm that makes password cracking attacks more
+    difficult.
+
+severity: medium
+
+identifiers:
+    cce@rhel6: 26303-8
+    cce@rhel7: 82043-1
+    cce@rhel8: 80893-1
+
+references:
+    stigid@rhel6: "000062"
+    srg@rhel6: SRG-OS-000120
+    disa@rhel6: '803'
+    cis: 6.3.1
+    cjis: 5.6.2.2
+    cui: 3.13.11
+    disa: "196"
+    nist: IA-5(b),IA-5(c),IA-5(1)(c),IA-7
+    nist-csf: PR.AC-1,PR.AC-6,PR.AC-7
+    pcidss: Req-8.2.1
+    srg: SRG-OS-000073-GPOS-00041
+    vmmsrg: SRG-OS-000480-VMM-002000
+    stigid@rhel7: "010200"
+    isa-62443-2013: 'SR 1.1,SR 1.10,SR 1.2,SR 1.3,SR 1.4,SR 1.5,SR 1.7,SR 1.8,SR 1.9,SR 2.1'
+    isa-62443-2009: 4.3.3.2.2,4.3.3.5.1,4.3.3.5.2,4.3.3.6.1,4.3.3.6.2,4.3.3.6.3,4.3.3.6.4,4.3.3.6.5,4.3.3.6.6,4.3.3.6.7,4.3.3.6.8,4.3.3.6.9,4.3.3.7.2,4.3.3.7.4
+    cobit5: DSS05.04,DSS05.05,DSS05.07,DSS05.10,DSS06.03,DSS06.10
+    iso27001-2013: A.18.1.4,A.7.1.1,A.9.2.1,A.9.2.2,A.9.2.3,A.9.2.4,A.9.2.6,A.9.3.1,A.9.4.2,A.9.4.3
+    cis-csc: 1,12,15,16,5
+
+ocil_clause: 'it does not'
+
+ocil: |-
+    Inspect the <tt>password</tt> section of <tt>/etc/pam.d/common-password</tt> and
+    ensure that the <tt>pam_unix.so</tt> module includes the argument
+    <tt>sha512</tt>:
+    <pre>$ grep sha512 /etc/pam.d/common-password</pre>
+
+platform: pam

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -1,9 +1,0 @@
-documentation_complete: true
-
-title: 'prueba'
-
-description: |- 
-    Write the profile description here
-
-selections:
-    - set_password_hashing_algorithm_systemauth_suse

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -6,4 +6,4 @@ description: |-
     Write the profile description here
 
 selections:
-    - bios_enable_execution_restrictions
+    - set_password_hashing_algorithm_systemauth_suse


### PR DESCRIPTION
… y fix

#### Description:

- Creada regla que fuerza que las contraseñas sigan el cifrado sha512 en SUSE.

#### Rationale:

- Modifica /etc/pam.d/common-password para añadir el argumento sha512 al modulo pam_unix.so
