### PR TITLE
Fix del sticky bits, primer commit

### DIFF
--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/ansible/shared.yml
@@ -1,19 +1,17 @@
-- name: Get local paths
-  shell: df --local -P | awk '{if (NR!=1) print $6}'
-  register: paths
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_rhv,multi_platform_sle
+# reboot = false
+# strategy = restrict
+# complexity = high
+# disruption = high
 
-- name: Find directories
-  find:
-    paths: "{{ item }}"
-    file_type: directory
-    recurse: no
-  register: change_perm
-  with_items: "{{ paths.stdout_lines | unique | list }}"
+- name: Get local paths
+  shell: find / -type d \( -perm -o+w \)
+  register: paths
+  ignore_errors: True
 
 - name: Change perms
   file:
-    path:  "{{ item.path }}"
-    mode:  g+s
+    path:  "{{ item }}"
+    mode:  a+t
   with_items:
-    -  "{{ change_perm.results[0].files }}"
-  when: item.mode == '0777'
+    -  "{{ paths.stdout_lines }}"

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/ansible/shared.yml
@@ -1,1 +1,19 @@
-- name: Find world writable dirs
+- name: Get local paths
+  shell: df --local -P | awk '{if (NR!=1) print $6}'
+  register: paths
+
+- name: Find directories
+  find:
+    paths: "{{ item }}"
+    file_type: directory
+    recurse: no
+  register: change_perm
+  with_items: "{{ paths.stdout_lines | unique | list }}"
+
+- name: Change perms
+  file:
+    path:  "{{ item.path }}"
+    mode:  g+s
+  with_items:
+    -  "{{ change_perm.results[0].files }}"
+  when: item.mode == '0777'

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/ansible/shared.yml
@@ -1,0 +1,1 @@
+- name: Find world writable dirs

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -6,4 +6,4 @@ description: |-
     Write the profile description here
 
 selections:
-    - bios_enable_execution_restrictions
+    - dir_perms_world_writable_sticky_bits

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -1,9 +1,0 @@
-documentation_complete: true
-
-title: 'prueba'
-
-description: |- 
-    Write the profile description here
-
-selections:
-    - dir_perms_world_writable_sticky_bits


### PR DESCRIPTION
#### Description:

- When the so-called 'sticky bit' is set on a directory,
    only the owner of a given file may remove that file from the
    directory. Without the sticky bit, any user with write access to a
    directory may remove any file in the directory. Setting the sticky
    bit prevents users from removing each other's files. In cases where
    there is no reason for a directory to be world-writable, a better
    solution is to remove that permission rather than to set the sticky
    bit. However, if a directory is used by a particular application,
    consult that application's documentation instead of blindly
    changing modes.
    To set the sticky bit on a world-writable directory *DIR*, run the
    following command:
```bash
$ sudo chmod +t <DIR>
```
#### Rationale:

-  Failing to set the sticky bit on public directories allows unauthorized
    users to delete files in the directory structure.
    The only authorized public directories are those temporary directories
    supplied with the system, or those designed to be temporary file
    repositories. The setting is normally reserved for directories used by the
    system, by users for temporary file storage (such as ```/tmp```), and
    for directories requiring global read/write access.