### PR TITLE
Ansible for sshd_disable_root_login

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_root_login/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_root_login/ansible/shared.yml
@@ -1,0 +1,18 @@
+# platform = multi_platform_fedora,multi_platform_rhel,multi_platform_rhv,multi_platform_sle
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+- name: Ensure disable root login
+  lineinfile:
+    path: /etc/ssh/sshd_config
+    regexp: '\#?PermitRootLogin.*'
+    line: PermitRootLogin no
+    state: present
+  register: sshd
+  
+- name: Restart service SSHD
+  service:
+    name: sshd
+    state: reloaded
+  when: sshd.changed


### PR DESCRIPTION
#### Description:
- The root user should never be allowed to login to a
    system directly over a network.
    To disable root login via SSH, add or correct the following line
    in ```/etc/ssh/sshd_config:
    PermitRootLogin no```

#### Rationale:
- Even though the communications channel may be encrypted, an additional layer of
    security is gained by extending the policy of not logging directly on as root.
    In addition, logging in with a user-specific account provides individual
    accountability of actions performed on the system and also helps to minimize
    direct attack attempts on root's password.