### PR TITLE
Ansible for sshd_disable_empty_passwords

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_empty_passwords/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_empty_passwords/ansible/shared.yml
@@ -1,0 +1,18 @@
+# platform = multi_platform_fedora,multi_platform_rhel,multi_platform_rhv,multi_platform_sle
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+- name: Ensure disable login without passwords
+  lineinfile:
+    path: /etc/ssh/sshd_config
+    regexp: '\#?PermitEmptyPasswords.*'
+    line: PermitEmptyPasswords no
+    state: present
+  register: sshd
+
+- name: Restart service SSHD
+  service:
+    name: sshd
+    state: reloaded
+  when: sshd.changed


### PR DESCRIPTION
#### Description:
- To explicitly disallow SSH login from accounts with
    empty passwords, add or correct the following line in **/etc/ssh/sshd_config**:
   ```PermitEmptyPasswords no```
    Any accounts with empty passwords should be disabled immediately, and PAM configuration
    should prevent users from being able to assign themselves empty passwords.

#### Rationale:
- Configuring this setting for the SSH daemon provides additional assurance
    that remote login via SSH will require a password, even in the event of 
    misconfiguration elsewhere.