### PR TITLE
Ansible para sshd_do_not_permit_user_env

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_do_not_permit_user_env/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_do_not_permit_user_env/ansible/shared.yml
@@ -1,0 +1,18 @@
+# platform = multi_platform_fedora,multi_platform_rhel,multi_platform_rhv,multi_platform_sle
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+- name: Ensure dissallow user env
+  lineinfile:
+    path: /etc/ssh/sshd_config
+    regexp: '\#?PermitUserEnvironment.*'
+    line: PermitUserEnvironment no
+    state: present
+  register: sshd
+
+- name: Restart service SSHD
+  service:
+    name: sshd
+    state: reloaded
+  when: sshd.changed

--- a/linux_os/guide/services/ssh/ssh_server/sshd_do_not_permit_user_env/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_do_not_permit_user_env/rule.yml
@@ -56,4 +56,4 @@ template:
         missing_parameter_pass: 'false'
         parameter: PermitUserEnvironment
         rule_id: sshd_do_not_permit_user_env
-        value: 'yes'
+        value: 'no'

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -6,4 +6,4 @@ description: |-
     Write the profile description here
 
 selections:
-    - bios_enable_execution_restrictions
+    - sshd_do_not_permit_user_env

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -1,9 +1,0 @@
-documentation_complete: true
-
-title: 'prueba'
-
-description: |- 
-    Write the profile description here
-
-selections:
-    - sshd_do_not_permit_user_env


### PR DESCRIPTION
#### Description:
- To ensure users are not able to override environment
    variables of the SSH daemon, add or correct the following line
    in **/etc/ssh/sshd_config**:
    ```PermitUserEnvironment no```

#### Rationale:
- SSH environment options potentially allow users to bypass
    access restriction in some configurations.