### PR TITLE
Ansible creado para regla no_shelllogin_for_systemaccounts

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/ansible/shared.yml
@@ -1,0 +1,30 @@
+# platform = multi_platform_sle
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+- name: Get UID less than 1000 whose name!=root
+  shell: cat /etc/passwd | awk -F{{ ":" }} '$3 < 1000 {print $1}' | grep -v 'root'
+  register: users
+
+- name: Block all system user accounts
+  shell: usermod -L {{ item }}
+  with_items: "{{ users.stdout_lines }}"
+
+- name: Get UID less than 1000 whose name!=root|sync|shutdown|halt
+  shell: cat /etc/passwd | awk -F{{ ":" }} '$3 < 1000 {print $1}' | grep -v "root" | grep -v "sync" | grep -v "shutdown" | grep -v "halt"
+  register: users2
+
+- name: change shell to /sbin/nologin
+  shell: usermod -s /sbin/nologin {{ item }}
+  with_items: "{{ users2.stdout_lines }}"
+
+
+
+
+
+
+
+
+

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -1,9 +1,0 @@
-documentation_complete: true
-
-title: 'prueba'
-
-description: |- 
-    Write the profile description here
-
-selections:
-    - no_shelllogin_for_systemaccounts

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -6,4 +6,4 @@ description: |-
     Write the profile description here
 
 selections:
-    - bios_enable_execution_restrictions
+    - no_shelllogin_for_systemaccounts


### PR DESCRIPTION
#### Description:

- Ansible creado para la regla "no_shelllogin_for_systemaccounts"

#### Rationale:

- El Ansible bloquea todas las cuentas cuyo UID<1000 & cuyo nombre!=root. Ademas especifica el shell /sbin/nologin para todas las cuentas cuyo UID<1000 & cuyo nombre!=root|shutdown|sync|halt tal como especifica el documento de seguridad.
