### PR TITLE
Corregidos varios errores de sintaxis en el ansible y el el OVAL

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/oval/shared.xml
@@ -13,22 +13,7 @@
       </affected>
       <description>Limit the Message Authentication Codes (MACs) to those which are FIPS-approved.</description>
     </metadata>
-    <criteria operator="AND">
-      <extend_definition comment="Installed OS is FIPS certified" definition_ref="installed_OS_is_FIPS_certified" />
-      <criteria comment="SSH is configured correctly or is not installed"
-      operator="OR">
-        <criteria comment="sshd is not installed" operator="AND">
-          <extend_definition comment="sshd is not required or requirement is unset"
-          definition_ref="sshd_not_required_or_unset" />
-          {{% if product in ['opensuse', 'sle11', 'sle12'] %}}
-          <extend_definition comment="rpm package openssh removed"
-          definition_ref="package_openssh_removed" />
-          {{% else %}}
-          <extend_definition comment="rpm package openssh-server removed"
-          definition_ref="package_openssh-server_removed" />
-          {{% endif %}}
-        </criteria>
-        <criteria comment="sshd is installed and configured" operator="AND">
+    <criteria comment="sshd is installed and configured" operator="AND">
           <extend_definition comment="sshd is required or requirement is unset"
           definition_ref="sshd_required_or_unset" />
           {{% if product in ['opensuse', 'sle11', 'sle12'] %}}
@@ -41,8 +26,6 @@
           <criterion comment="Check MACs in /etc/ssh/sshd_config"
           test_ref="test_sshd_use_approved_macs" />
         </criteria>
-      </criteria>
-    </criteria>
   </definition>
 
   <ind:variable_test check="at least one"

--- a/linux_os/guide/services/ssh/sshd_approved_macs.var
+++ b/linux_os/guide/services/ssh/sshd_approved_macs.var
@@ -12,4 +12,4 @@ interactive: false
 
 options:
     sle12_stig: hmac-sha2-512,hmac-sha2-256
-    default: hmac-sha2-512,hmac-sha2-256,hmac-sha1,hmac-sha1-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com
+    default: hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -1,9 +1,0 @@
-documentation_complete: true
-
-title: 'prueba'
-
-description: |- 
-    Write the profile description here
-
-selections:
-    - sshd_use_approved_macs

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -6,4 +6,4 @@ description: |-
     Write the profile description here
 
 selections:
-    - bios_enable_execution_restrictions
+    - sshd_use_approved_macs


### PR DESCRIPTION
#### Description:

- Corregidos varios errores de sintaxis en el ansible y el el OVAL.

#### Rationale:

- Los algoritmos MAC no estaban escritos correctamente y había checks oval que no funcionaban de la manera especificada en el documento de seguridad.
