### PR TITLE
Ansible para sshd_idle_timeout_value

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/ansible/shared.yml
@@ -3,6 +3,18 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-- (xccdf-var sshd_idle_timeout_value)
+### To set the numer to a variable, please execute like ansible-playbook playbook.yml --extra-vars "seconds=***desired seconds***"
 
-{{{ ansible_sshd_set(parameter="ClientAliveInterval", value="{{ sshd_idle_timeout_value }}") }}}
+- name: Ensure ClientAliveInterval set to variable
+  lineinfile:
+    path: /etc/ssh/sshd_config
+    regexp: '\#?ClientAliveInterval.*'
+    line: ClientAliveInterval {{ seconds }}
+    state: present
+  register: sshd
+
+- name: Restart service SSHD
+  service:
+    name: sshd
+    state: restarted
+  when: sshd.changed

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/ansible/shared.yml
@@ -16,5 +16,5 @@
 - name: Restart service SSHD
   service:
     name: sshd
-    state: restarted
+    state: reloaded
   when: sshd.changed

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/ansible/shared.yml
@@ -3,7 +3,7 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-### To set the numer to a variable, please execute like ansible-playbook playbook.yml --extra-vars "seconds=***desired seconds***"
+### To set the number to a variable, please execute like ansible-playbook playbook.yml --extra-vars "seconds=***desired seconds***"
 
 - name: Ensure ClientAliveInterval set to variable
   lineinfile:

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/oval/shared.xml
@@ -9,20 +9,7 @@
       <description>The SSH idle timeout interval should be set to an
       appropriate value.</description>
     </metadata>
-    <criteria comment="SSH is configured correctly or is not installed"
-    operator="OR">
-      <criteria comment="sshd is not installed" operator="AND">
-        <extend_definition comment="sshd is not required or requirement is unset"
-        definition_ref="sshd_not_required_or_unset" />
-        {{% if product in ['opensuse', 'sle11', 'sle12'] %}}
-        <extend_definition comment="rpm package openssh removed"
-        definition_ref="package_openssh_removed" />
-        {{% else %}}
-        <extend_definition comment="rpm package openssh-server removed"
-        definition_ref="package_openssh-server_removed" />
-        {{% endif %}}
-      </criteria>
-      <criteria comment="sshd is installed and configured" operator="AND">
+    <criteria comment="sshd is installed and configured" operator="AND">
         <extend_definition comment="sshd is required or requirement is unset"
         definition_ref="sshd_required_or_unset" />
         {{% if product in ['opensuse', 'sle11', 'sle12'] %}}
@@ -35,7 +22,6 @@
         <criterion comment="Check ClientAliveInterval in /etc/ssh/sshd_config"
         test_ref="test_sshd_idle_timeout" />
       </criteria>
-    </criteria>
   </definition>
 
   <ind:textfilecontent54_test check="all" check_existence="all_exist"

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -1,9 +1,0 @@
-documentation_complete: true
-
-title: 'prueba'
-
-description: |- 
-    Write the profile description here
-
-selections:
-    - sshd_set_idle_timeout

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -6,4 +6,4 @@ description: |-
     Write the profile description here
 
 selections:
-    - bios_enable_execution_restrictions
+    - sshd_set_idle_timeout


### PR DESCRIPTION
#### Description:

- SSH allows administrators to set an idle timeout
    interval.
    After this interval has passed, the idle user will be
    automatically logged out.
    To set an idle timeout interval, edit the following line in ```/etc/ssh/sshd_config``` as
    follows:
    <pre>ClientAliveInterval <b><sub idref="sshd_idle_timeout_value" /></b></pre>
    The timeout <b>interval</b> is given in seconds. To have a timeout
    of e.g. 10 minutes, set <b>interval</b> to 600.
    If a shorter timeout has already been set for the login
    shell, that value will preempt any SSH
    setting made here. Keep in mind that some processes may stop SSH
    from correctly detecting that the user is idle.

#### Rationale:

- Terminating an idle ssh session within a short time period reduces the window of
    opportunity for unauthorized personnel to take control of a management session
    enabled on the console or console port that has been let unattended.
