### PR TITLE
Regla package_libselinux1_installed creada en base a plantilla

### DIFF
--- a/linux_os/guide/system/selinux/package_libselinux1_installed/rule.yml
+++ b/linux_os/guide/system/selinux/package_libselinux1_installed/rule.yml
@@ -1,0 +1,16 @@
+documentation_complete: true
+
+prodtype: sle11,sle12
+
+title: 'Install the libselinux1 package'
+
+description: 'The libselinux1 package should be installed.'
+
+rationale: 'The libselinux1 package should be installed.'
+
+severity: high
+
+template:
+    name: package_installed
+    vars:
+        pkgname: libselinux1

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -1,9 +1,0 @@
-documentation_complete: true
-
-title: 'prueba'
-
-description: |- 
-    Write the profile description here
-
-selections:
-    - package_libselinux1_installed

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -6,4 +6,4 @@ description: |-
     Write the profile description here
 
 selections:
-    - bios_enable_execution_restrictions
+    - package_libselinux1_installed


### PR DESCRIPTION
#### Description:

- El paquete libselinux1 debe ser instalado.

#### Rationale:

- Instala el paquete libselinux1 para asegurarse de que las funcionalidades de SElinux están disponibles en el sistema.


