### PR TITLE
Regla service_rsyncd_disabled creada en base a plantilla

### DIFF
--- a/linux_os/guide/services/base/service_rsyncd_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_rsyncd_disabled/rule.yml
@@ -1,0 +1,23 @@
+documentation_complete: true
+
+prodtype: sle12
+
+title: 'Disable rsyncd service'
+
+description: |-
+    Disable rsyncd service.
+
+rationale: |-
+    Disable rsyncd service.
+
+severity: medium
+
+ocil: 'Ensure service rsyncd is disabled'
+
+platform: machine
+
+template:
+    name: service_disabled
+    vars:
+        servicename: rsyncd
+        packagename: rsync

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -1,9 +1,0 @@
-documentation_complete: true
-
-title: 'prueba'
-
-description: |- 
-    Write the profile description here
-
-selections:
-    - service_rsyncd_disabled

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -6,4 +6,4 @@ description: |-
     Write the profile description here
 
 selections:
-    - bios_enable_execution_restrictions
+    - service_rsyncd_disabled


### PR DESCRIPTION
#### Description:

- El servicio rsyncd debe ser deshabilitado

#### Rationale:

- El servicio rsyncd se puede usar para sincronizar archivos entre sistemas a través de enlaces
de red.

