### PR TITLE
Regla sysctl_net_ipv6_conf_all_accept_redirects creada en base a plan…

### DIFF
--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/sysctl_net_ipv6_conf_all_accept_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/sysctl_net_ipv6_conf_all_accept_redirects/rule.yml
@@ -1,0 +1,22 @@
+documentation_complete: true
+
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,sle12,wrlinux1019
+
+title: 'Disable the possibility to accept ICMP redirects'
+
+description: |-
+    Disable the possibility to accept ICMP redirects.
+
+rationale: |-
+    Disable the possibility to accept ICMP redirects.
+
+severity: medium
+
+platform: machine
+
+template:
+    name: sysctl
+    vars:
+        sysctlvar: net.ipv6.conf.all.accept_redirects
+        sysctlval: '0'
+        datatype: int


### PR DESCRIPTION
…tilla

#### Description:

- Ensure net.ipv6.conf.all.accept_redirect = 0

#### Rationale:

- Esta configuración evita que el sistema acepte re-direccionamientos ICMP. Las re direcciones
ICMP le dicen al sistema sobre rutas alternativas para enviar tráfico.

