### PR TITLE
Regla file_permissions_etc_hosts_allow creada en base a plantilla

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_hosts_allow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_hosts_allow/rule.yml
@@ -1,0 +1,25 @@
+documentation_complete: true
+
+prodtype: sle11,sle12
+
+title: 'Verify Permissions on hosts.allow File'
+
+description: |-
+    Verify Permissions on hosts.allow File.
+
+rationale: |-
+    If the <tt>/etc/hosts.allow</tt> file is writable by a group-owner or the
+    world the risk of its compromise is increased.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/hosts.allow", perms="-rw-r--r--") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/etc/hosts.allow", perms="-rw-r--r--") }}}
+
+template:
+    name: file_permissions
+    vars:
+        filepath: /etc/hosts.allow
+        filemode: '0644'

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -6,19 +6,4 @@ description: |-
     Write the profile description here
 
 selections:
-    - file_owner_grub2_cfg
-    - file_groupowner_grub2_cfg
-    - disable_users_coredumps
-    - sysctl_fs_suid_dumpable
-    - sysctl_net_ipv6_conf_all_disable_ipv6
-    - audit_rules_kernel_module_loading
-    - audit_rules_kernel_module_loading_delete
-    - audit_rules_kernel_module_loading_finit
-    - audit_rules_kernel_module_loading_init
-    - file_owner_sshd_config
-    - file_groupowner_sshd_config
-    - file_permissions_sshd_config
-    - file_permissions_etc_passwd
-    - file_permissions_etc_shadow
-    - file_permissions_etc_group
-    - file_permissions_etc_gshadow
+    - file_permissions_etc_hosts_allow

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -1,9 +1,0 @@
-documentation_complete: true
-
-title: 'prueba'
-
-description: |- 
-    Write the profile description here
-
-selections:
-    - file_permissions_etc_hosts_allow


### PR DESCRIPTION
#### Description:

- Verify Permissions on hosts.allow File.

#### Rationale:

- El archivo /etc/hosts.allow contiene información de red que utilizan muchas aplicaciones y, por
lo tanto, debe ser legible para que estas aplicaciones funcionen.
