### PR TITLE
Regla file_groupowner_etc_hosts_allow creada en base a pantilla

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_hosts_allow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_hosts_allow/rule.yml
@@ -1,0 +1,21 @@
+documentation_complete: true
+
+title: 'Verify Group Who Owns hosts.allow File'
+
+description: '{{{ describe_file_group_owner(file="/etc/hosts.allow", group="root") }}}'
+
+rationale: |-
+    El archivo /etc/hosts.allow contiene información de red que utilizan muchas aplicaciones y, por
+lo tanto, debe ser legible para que estas aplicaciones funcionen.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/hosts.allow", group="root") }}}'
+
+ocil: '{{{ ocil_file_group_owner(file="/etc/hosts.allow", group="root") }}}'
+
+template:
+    name: file_groupowner
+    vars:
+        filepath: /etc/hosts.allow
+        filegid: '0'


### PR DESCRIPTION
#### Description:

- Verify group owner of /etc/hosts.allow file.

#### Rationale:

- El archivo /etc/hosts.allow contiene información de red que utilizan muchas aplicaciones y, por
lo tanto, debe ser legible para que estas aplicaciones funcionen.
