### PR TITLE
Regla file_owner_etc_hosts_deny creada en base a plantilla

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_hosts_deny/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_hosts_deny/rule.yml
@@ -1,0 +1,21 @@
+documentation_complete: true
+
+title: 'Verify User Who Owns hosts.deny File'
+
+description: 'Verify ownership of hosts.deny file'
+
+rationale: |-
+    El archivo /etc/hosts.deny contiene información de red que utilizan muchas aplicaciones del
+sistema y, por lo tanto, debe ser legible para que estas aplicaciones funcionen.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/hosts.deny", owner="root") }}}'
+
+ocil: '{{{ ocil_file_owner(file="/etc/hosts.deny", owner="root") }}}'
+
+template:
+    name: file_owner
+    vars:
+        filepath: /etc/hosts.deny
+        fileuid: '0'


### PR DESCRIPTION
#### Description:

- Verify owner of /etc/hosts.deny file.

#### Rationale:

- El archivo /etc/hosts.deny contiene información de red que utilizan muchas aplicaciones del
sistema y, por lo tanto, debe ser legible para que estas aplicaciones funcionen.