### PR TITLE
Regla file_permissions_cron_allow creada en base a plantilla

### DIFF
--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_permissions_cron_allow/rule.yml
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_permissions_cron_allow/rule.yml
@@ -1,0 +1,24 @@
+documentation_complete: true
+
+prodtype: sle11,sle12
+
+title: 'Verify Permissions on cron.allow File'
+
+description: |-
+    Verify Permissions on cron.allow File
+
+rationale: |-
+    Verify Permissions on cron.allow File
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/cron.allow", perms="-rw-------") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/etc/cron.allow", perms="-rw-------") }}}
+
+template:
+    name: file_permissions
+    vars:
+        filepath: /etc/cron.allow
+        filemode: '0600'


### PR DESCRIPTION
#### Description:

- Verify /etc/cron.allow file permissions.

#### Rationale:

- Verify /etc/cron.allow file permissions.
