### PR TITLE
Reglas file_groupowner_at_allow, file_owner_at_allow y file_permissio…

### DIFF
--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_groupowner_at_allow/rule.yml
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_groupowner_at_allow/rule.yml
@@ -1,0 +1,26 @@
+documentation_complete: true
+
+prodtype: multi_platform_sle,rhel7,rhel8,rhv4,sle11,sle12,wrlinux1019
+
+title: 'Verify Group Who Owns /etc/at.allow file'
+
+description: |-
+    If <tt>/etc/at.allow</tt> exists, it must be group-owned by <tt>root</tt>.
+    {{{ describe_file_group_owner(file="/etc/at.allow", group="root") }}}
+
+rationale: |-
+    If the owner of the at.allow file is not set to root, the possibility exists for an
+    unauthorized user to view or edit sensitive information.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/at.allow", group="root") }}}'
+
+ocil: '{{{ ocil_file_group_owner(file="/etc/at.allow", group="root") }}}'
+
+template:
+    name: file_groupowner
+    vars:
+        filepath: /etc/at.allow
+        missing_file_pass: 'true'
+        filegid: '0'

--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_owner_at_allow/rule.yml
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_owner_at_allow/rule.yml
@@ -1,0 +1,26 @@
+documentation_complete: true
+
+prodtype: multi_platform_sle,rhel7,rhel8,rhv4,sle11,sle12,wrlinux1019
+
+title: 'Verify User Who Owns /etc/at.allow file'
+
+description: |-
+    If <tt>/etc/at.allow</tt> exists, it must be owned by <tt>root</tt>.
+    {{{ describe_file_owner(file="/etc/at.allow", owner="root") }}}
+
+rationale: |-
+    If the owner of the at.allow file is not set to root, the possibility exists for an
+    unauthorized user to view or edit sensitive information.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/at.allow", owner="root") }}}'
+
+ocil: '{{{ ocil_file_owner(file="/etc/at.allow", owner="root") }}}'
+
+template:
+    name: file_owner
+    vars:
+        filepath: /etc/at.allow
+        missing_file_pass: 'true'
+        fileuid: '0'

--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_permissions_at_allow/rule.yml
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_permissions_at_allow/rule.yml
@@ -1,0 +1,24 @@
+documentation_complete: true
+
+prodtype: sle11,sle12
+
+title: 'Verify Permissions on at.allow File'
+
+description: |-
+    Verify Permissions on at.allow File
+
+rationale: |-
+    Verify Permissions on at.allow File
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/at.allow", perms="-rw-------") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/etc/at.allow", perms="-rw-------") }}}
+
+template:
+    name: file_permissions
+    vars:
+        filepath: /etc/at.allow
+        filemode: '0600'


### PR DESCRIPTION
#### Description:

- Reglas file_groupowner_at_allow, file_owner_at_allow y file_permissions_at_allow creadas en base a plantilla

#### Rationale:

- Reglas file_groupowner_at_allow, file_owner_at_allow y file_permissions_at_allow creadas en base a plantilla

