### PR TITLE
Reglas file_groupowner_etc_motd, file_owner_etc_motd y file_permissio…

### DIFF
--- a/linux_os/guide/system/accounts/accounts-banners/file_groupowner_etc_motd/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/file_groupowner_etc_motd/rule.yml
@@ -1,0 +1,26 @@
+documentation_complete: true
+
+prodtype: multi_platform_sle,rhel7,rhel8,rhv4,sle11,sle12,wrlinux1019
+
+title: 'Verify Group Who Owns /etc/motd file'
+
+description: |-
+    If <tt>/etc/motd</tt> exists, it must be group-owned by <tt>root</tt>.
+    {{{ describe_file_group_owner(file="/etc/motd", group="root") }}}
+
+rationale: |-
+    If the owner of the motd file is not set to root, the possibility exists for an
+    unauthorized user to view or edit sensitive information.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/motd", group="root") }}}'
+
+ocil: '{{{ ocil_file_group_owner(file="/etc/motd", group="root") }}}'
+
+template:
+    name: file_groupowner
+    vars:
+        filepath: /etc/motd
+        missing_file_pass: 'true'
+        filegid: '0'

--- a/linux_os/guide/system/accounts/accounts-banners/file_owner_etc_motd/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/file_owner_etc_motd/rule.yml
@@ -1,0 +1,26 @@
+documentation_complete: true
+
+prodtype: multi_platform_sle,rhel7,rhel8,rhv4,sle11,sle12,wrlinux1019
+
+title: 'Verify User Who Owns /etc/motd file'
+
+description: |-
+    If <tt>/etc/motd</tt> exists, it must be owned by <tt>root</tt>.
+    {{{ describe_file_owner(file="/etc/motd", owner="root") }}}
+
+rationale: |-
+    If the owner of the motd file is not set to root, the possibility exists for an
+    unauthorized user to view or edit sensitive information.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/motd", owner="root") }}}'
+
+ocil: '{{{ ocil_file_owner(file="/etc/motd", owner="root") }}}'
+
+template:
+    name: file_owner
+    vars:
+        filepath: /etc/motd
+        missing_file_pass: 'true'
+        fileuid: '0'

--- a/linux_os/guide/system/accounts/accounts-banners/file_permissions_etc_motd/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/file_permissions_etc_motd/rule.yml
@@ -1,0 +1,24 @@
+documentation_complete: true
+
+prodtype: sle11,sle12
+
+title: 'Verify Permissions on motd File'
+
+description: |-
+    Verify Permissions on motd File
+
+rationale: |-
+    Verify Permissions on motd File
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/motd", perms="-rw-------") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/etc/motd", perms="-rw-r--r--") }}}
+
+template:
+    name: file_permissions
+    vars:
+        filepath: /etc/motd
+        filemode: '0644'


### PR DESCRIPTION
…ns_etc_motd creadas a partir de plantilla

#### Description:

- Reglas file_groupowner_etc_motd, file_owner_etc_motd y file_permissions_etc_motd creadas a partir de plantilla

#### Rationale:

- Reglas file_groupowner_etc_motd, file_owner_etc_motd y file_permissions_etc_motd creadas a partir de plantilla

