### PR TITLE
Reglas file_groupowner_etc_shadow-, file_owner_etc_shadow- y file_per…

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_shadow-/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_shadow-/rule.yml
@@ -1,0 +1,21 @@
+documentation_complete: true
+
+title: 'Verify Group Who Owns shadow- File'
+
+description: '{{{ describe_file_group_owner(file="/etc/shadow-", group="root") }}}'
+
+rationale: |-
+    The <tt>/etc/shadow-</tt> file contains information about the users that are configured on
+    the system. Protection of this file is critical for system security.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/shadow-", group="root") }}}'
+
+ocil: '{{{ ocil_file_group_owner(file="/etc/shadow-", group="root") }}}'
+
+template:
+    name: file_groupowner
+    vars:
+        filepath: /etc/shadow-
+        filegid: '0'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_shadow-/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_shadow-/rule.yml
@@ -1,0 +1,21 @@
+documentation_complete: true
+
+title: 'Verify User Who Owns shadow- File'
+
+description: '{{{ describe_file_owner(file="/etc/shadow-", owner="root") }}}'
+
+rationale: |-
+    The <tt>/etc/shadow-</tt> file contains information about the users that are configured on
+    the system. Protection of this file is critical for system security.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/shadow-", owner="root") }}}'
+
+ocil: '{{{ ocil_file_owner(file="/etc/shadow-", owner="root") }}}'
+
+template:
+    name: file_owner
+    vars:
+        filepath: /etc/shadow-
+        fileuid: '0'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_shadow-/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_shadow-/rule.yml
@@ -1,0 +1,27 @@
+documentation_complete: true
+
+prodtype: multi_platform_sle,sle11,sle12
+
+title: 'Verify Permissions on shadow- File'
+
+description: |-
+    {{{ describe_file_permissions(file="/etc/shadow-", perms="0644") }}}
+
+rationale: |-
+    If the <tt>/etc/shadow-</tt> file is writable by a group-owner or the
+    world the risk of its compromise is increased. The file contains the list of
+    accounts on the system and associated information, and protection of this file
+    is critical for system security.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/shadow-", perms="-rw-r--r--") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/etc/shadow-", perms="-rw-r--r--") }}}
+
+template:
+    name: file_permissions
+    vars:
+        filepath: /etc/shadow-
+        filemode: '0644'


### PR DESCRIPTION
…missions_etc_shadow- creadas en base a plantilla

#### Description:

- Reglas file_groupowner_etc_shadow-, file_owner_etc_shadow- y file_permissions_etc_shadow- creadas en base a plantilla.

#### Rationale:

- Reglas file_groupowner_etc_shadow-, file_owner_etc_shadow- y file_permissions_etc_shadow- creadas en base a plantilla.

