### PR TITLE
Reglas file_groupowner_etc_gshadow-, file_owner_etc_gshadow- y file_p…

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_gshadow-/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_gshadow-/rule.yml
@@ -1,0 +1,21 @@
+documentation_complete: true
+
+title: 'Verify Group Who Owns gshadow- File'
+
+description: '{{{ describe_file_group_owner(file="/etc/gshadow-", group="root") }}}'
+
+rationale: |-
+    The <tt>/etc/gshadow-</tt> file contains information about the users that are configured on
+    the system. Protection of this file is critical for system security.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/gshadow-", group="root") }}}'
+
+ocil: '{{{ ocil_file_group_owner(file="/etc/gshadow-", group="root") }}}'
+
+template:
+    name: file_groupowner
+    vars:
+        filepath: /etc/gshadow-
+        filegid: '0'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_gshadow-/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_gshadow-/rule.yml
@@ -1,0 +1,21 @@
+documentation_complete: true
+
+title: 'Verify User Who Owns gshadow- File'
+
+description: '{{{ describe_file_owner(file="/etc/gshadow-", owner="root") }}}'
+
+rationale: |-
+    The <tt>/etc/gshadow-</tt> file contains information about the users that are configured on
+    the system. Protection of this file is critical for system security.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/gshadow-", owner="root") }}}'
+
+ocil: '{{{ ocil_file_owner(file="/etc/gshadow-", owner="root") }}}'
+
+template:
+    name: file_owner
+    vars:
+        filepath: /etc/gshadow-
+        fileuid: '0'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_gshadow-/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_gshadow-/rule.yml
@@ -1,0 +1,27 @@
+documentation_complete: true
+
+prodtype: multi_platform_sle,sle11,sle12
+
+title: 'Verify Permissions on gshadow- File'
+
+description: |-
+    {{{ describe_file_permissions(file="/etc/gshadow-", perms="0644") }}}
+
+rationale: |-
+    If the <tt>/etc/gshadow-</tt> file is writable by a gshadow-owner or the
+    world the risk of its compromise is increased. The file contains the list of
+    accounts on the system and associated information, and protection of this file
+    is critical for system security.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/gshadow-", perms="-rw-r--r--") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/etc/gshadow-", perms="-rw-r--r--") }}}
+
+template:
+    name: file_permissions
+    vars:
+        filepath: /etc/gshadow-
+        filemode: '0644'


### PR DESCRIPTION
…ermissions_etc_gshadow- creadas en base a plantilla

#### Description:

- Reglas file_groupowner_etc_gshadow-, file_owner_etc_gshadow- y file_permissions_etc_gshadow- creadas en base a plantilla.

#### Rationale:

- Reglas file_groupowner_etc_gshadow-, file_owner_etc_gshadow- y file_permissions_etc_gshadow- creadas en base a plantilla.

