### PR TITLE
Regla file_delete_at_deny_and_cron_deny creada con check y fix

### DIFF
--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_delete_at_deny_and_cron_deny/ansible/shared.yml
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_delete_at_deny_and_cron_deny/ansible/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+- name: Remove file at.deny
+  file:
+    path: /etc/at.deny
+    state: absent
+
+- name: Remove file cron.deny
+  file:
+    path: /etc/cron.deny
+    state: absent

--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_delete_at_deny_and_cron_deny/oval/shared.xml
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_delete_at_deny_and_cron_deny/oval/shared.xml
@@ -1,0 +1,33 @@
+<def-group>
+  <definition class="compliance" id="file_delete_at_deny_and_cron_deny" version="1">
+    <metadata>
+      <title>Delete at.deny and cron.deny files</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>Delete at.deny and cron.deny files</description>
+    </metadata>
+    <criteria operator="AND">
+      <criterion comment="Delete at.deny file" test_ref="test_file_delete_at_deny" />
+      <criterion comment="Delete cron.deny file" test_ref="test_file_delete_cron_deny" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="none_exist" comment="/etc/at.deny file exists" id="test_file_delete_at_deny" version="1">
+    <ind:object object_ref="object_file_delete_at_deny" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object comment="Delete at.deny file" id="object_file_delete_at_deny" version="1">
+    <ind:filepath>/etc/at.deny</ind:filepath>
+    <ind:pattern operation="pattern match">^.*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" check_existence="none_exist" comment="/etc/cron.deny file exists" id="test_file_delete_cron_deny" version="1">
+    <ind:object object_ref="object_file_delete_cron_deny" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object comment="Delete cron.deny file" id="object_file_delete_cron_deny" version="1">
+    <ind:filepath>/etc/cron.deny</ind:filepath>
+    <ind:pattern operation="pattern match">^.*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>

--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_delete_at_deny_and_cron_deny/rule.yml
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_delete_at_deny_and_cron_deny/rule.yml
@@ -1,0 +1,13 @@
+documentation_complete: true
+
+prodtype: multi_platform_sle,rhel7,rhel8,rhv4,sle11,sle12,wrlinux1019
+
+title: 'Delete at.deny and cron.deny files'
+
+description: |-
+    Delete at.deny and cron.deny files.
+
+rationale: |-
+    Delete at.deny and cron.deny files.
+
+severity: medium

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -6,19 +6,4 @@ description: |-
     Write the profile description here
 
 selections:
-    - file_owner_grub2_cfg
-    - file_groupowner_grub2_cfg
-    - disable_users_coredumps
-    - sysctl_fs_suid_dumpable
-    - sysctl_net_ipv6_conf_all_disable_ipv6
-    - audit_rules_kernel_module_loading
-    - audit_rules_kernel_module_loading_delete
-    - audit_rules_kernel_module_loading_finit
-    - audit_rules_kernel_module_loading_init
-    - file_owner_sshd_config
-    - file_groupowner_sshd_config
-    - file_permissions_sshd_config
-    - file_permissions_etc_passwd
-    - file_permissions_etc_shadow
-    - file_permissions_etc_group
-    - file_permissions_etc_gshadow
+    - file_delete_at_deny_and_cron_deny

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -1,9 +1,0 @@
-documentation_complete: true
-
-title: 'prueba'
-
-description: |- 
-    Write the profile description here
-
-selections:
-    - file_delete_at_deny_and_cron_deny


### PR DESCRIPTION
#### Description:

- Ensure /etc/at.deny and /etc/cron.deny files does not exist.

#### Rationale:

- Al eliminar los archivos, solo los usuarios de /etc/cron.allow y /etc/at.allow pueden usar
at y cron.

