### PR TITLE
Regla sshd_LoginGraceTime creada en bse a plantilla

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_LoginGraceTime/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_LoginGraceTime/rule.yml
@@ -1,0 +1,19 @@
+documentation_complete: true
+
+title: 'Ensure LoginGraceTime is set to one minute'
+
+description: |-
+    Ensure LoginGraceTime is set to one minute.
+
+rationale: |-
+    Ensure LoginGraceTime is set to one minute.
+
+severity: high
+
+template:
+    name: sshd_lineinfile
+    vars:
+        missing_parameter_pass: 'false'
+        parameter: LoginGraceTime
+        rule_id: sshd_LoginGraceTime
+        value: '60'

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -1,9 +1,0 @@
-documentation_complete: true
-
-title: 'prueba'
-
-description: |- 
-    Write the profile description here
-
-selections:
-    - sshd_LoginGraceTime

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -6,19 +6,4 @@ description: |-
     Write the profile description here
 
 selections:
-    - file_owner_grub2_cfg
-    - file_groupowner_grub2_cfg
-    - disable_users_coredumps
-    - sysctl_fs_suid_dumpable
-    - sysctl_net_ipv6_conf_all_disable_ipv6
-    - audit_rules_kernel_module_loading
-    - audit_rules_kernel_module_loading_delete
-    - audit_rules_kernel_module_loading_finit
-    - audit_rules_kernel_module_loading_init
-    - file_owner_sshd_config
-    - file_groupowner_sshd_config
-    - file_permissions_sshd_config
-    - file_permissions_etc_passwd
-    - file_permissions_etc_shadow
-    - file_permissions_etc_group
-    - file_permissions_etc_gshadow
+    - sshd_LoginGraceTime


### PR DESCRIPTION
#### Description:

- Ensure LoginGraceTime is set to one minute.

#### Rationale:

- El parámetro LoginGraceTime especifica el tiempo permitido para la autenticación exitosa en el
servidor SSH. Cuanto más largo sea el período de gracia, más abiertas pueden existir
conexiones no autenticadas. Al igual que otros controles de sesión en esta sesión, el Período
de gracia debe limitarse a los límites organizativos apropiados para garantizar que el servicio
esté disponible para el acceso necesario.

