### PR TITLE
Regla account_unique_uid creada con check OVAL

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_unique_uid/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_unique_uid/oval/shared.xml
@@ -1,0 +1,66 @@
+<def-group>
+  <definition class="compliance" id="account_unique_uid" version="1">
+    <metadata>
+      <title>Set All Accounts To Have Unique UIDs</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+        <platform>multi_platform_sle</platform>
+      </affected>
+      <description>All accounts on the system should have unique UIDs for proper accountability.</description>
+    </metadata>
+
+      <criteria comment="There should not exist duplicate uids entries in /etc/passwd">
+        <criterion test_ref="test_etc_passwd_no_duplicate_uid" />
+      </criteria>
+
+  </definition>
+
+  <!-- OVAL object to collect content of /etc/group file -->
+  <ind:textfilecontent54_object id="object_account_unique_uid_get" version="1">
+    <ind:filepath>/etc/passwd</ind:filepath>
+    <!-- Group ID (GID) from /etc/group (3-rd column) captured as subexpression of this object -->
+    <ind:pattern operation="pattern match">^.*:x:([0-9]+):</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <!-- OVAL variable to hold the count of all the UID defined in /etc/passwd
+       (including duplicate entries if any) -->
+  <local_variable id="variable_count_of_all_uid_from_etc_passwd" datatype="int" version="1"
+  comment="Count of all UID rows retrieved from /etc/passwd (including duplicates if any)">
+    <count>
+      <object_component item_field="subexpression" object_ref="object_account_unique_uid_get" />
+    </count>
+  </local_variable>
+
+  <!-- Turn the OVAL variable representing count of uids into OVAL object
+       (for use in <variable_test> below)-->
+  <ind:variable_object id="object_count_of_all_uid_from_etc_passwd" version="1">
+    <ind:var_ref>variable_count_of_all_uid_from_etc_passwd</ind:var_ref>
+  </ind:variable_object>
+
+  <!-- OVAL variable to hold the count of unique uids defined in /etc/passwd -->
+  <local_variable id="variable_count_of_unique_uid_from_etc_passwd" datatype="int" version="1"
+  comment="Count of unique uid rows retrieved from /etc/passwd">
+    <count>
+      <unique>
+        <object_component item_field="subexpression" object_ref="object_account_unique_uid_get" />
+      </unique>
+    </count>
+  </local_variable>
+
+  <!-- Create OVAL state from count of unique usernames OVAL variable (to be used in
+       <variable_test> below -->
+  <ind:variable_state id="state_etc_passwd_no_duplicate_uid" version="1">
+    <ind:value var_ref="variable_count_of_unique_uid_from_etc_passwd" datatype="int"
+    operation="equals" var_check="at least one" />
+  </ind:variable_state>
+
+  <!-- Check if count of all the different usernames defined in /etc/passwd matches the count
+       of all unique usernames defined in /etc/passwd (IOW if there aren't duplicate entries) -->
+  <ind:variable_test id="test_etc_passwd_no_duplicate_uid" check="all" check_existence="all_exist"
+  comment="There should not exist duplicate uid entries in /etc/passwd" version="1">
+    <ind:object object_ref="object_count_of_all_uid_from_etc_passwd" />
+    <ind:state state_ref="state_etc_passwd_no_duplicate_uid" />
+  </ind:variable_test>
+
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_unique_uid/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_unique_uid/rule.yml
@@ -1,0 +1,18 @@
+documentation_complete: true
+
+prodtype: multi_platform_sle,sle11,sle12
+
+title: 'Ensure All Accounts on the System Have Unique UIDs'
+
+description: 'Change UIDs, or delete accounts, so each has a unique name.'
+
+rationale: 'Unique UIDs allow for accountability on the system.'
+
+severity: medium
+
+ocil_clause: 'a line is returned'
+
+ocil: |-
+    Run the following command to check for duplicate account UIDs:
+    <pre>$ sudo pwck -qr</pre>
+    If there are no duplicate UIDs, no line will be returned.

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -1,9 +1,0 @@
-documentation_complete: true
-
-title: 'prueba'
-
-description: |- 
-    Write the profile description here
-
-selections:
-    - account_unique_uid

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -6,19 +6,4 @@ description: |-
     Write the profile description here
 
 selections:
-    - file_owner_grub2_cfg
-    - file_groupowner_grub2_cfg
-    - disable_users_coredumps
-    - sysctl_fs_suid_dumpable
-    - sysctl_net_ipv6_conf_all_disable_ipv6
-    - audit_rules_kernel_module_loading
-    - audit_rules_kernel_module_loading_delete
-    - audit_rules_kernel_module_loading_finit
-    - audit_rules_kernel_module_loading_init
-    - file_owner_sshd_config
-    - file_groupowner_sshd_config
-    - file_permissions_sshd_config
-    - file_permissions_etc_passwd
-    - file_permissions_etc_shadow
-    - file_permissions_etc_group
-    - file_permissions_etc_gshadow
+    - account_unique_uid


### PR DESCRIPTION
#### Description:

- Comprueba que no existan UIDs duplicados.

#### Rationale:

- Comprueba que no existan UIDs duplicados.

