### PR TITLE
Regla account_unique_gid creada con check OVAL

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_unique_gid/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_unique_gid/oval/shared.xml
@@ -1,0 +1,66 @@
+<def-group>
+  <definition class="compliance" id="account_unique_gid" version="1">
+    <metadata>
+      <title>Set All Accounts To Have Unique GIDs</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+        <platform>multi_platform_sle</platform>
+      </affected>
+      <description>All accounts on the system should have unique GIDs for proper accountability.</description>
+    </metadata>
+
+      <criteria comment="There should not exist duplicate gids entries in /etc/group">
+        <criterion test_ref="test_etc_group_no_duplicate_gid" />
+      </criteria>
+
+  </definition>
+
+  <!-- OVAL object to collect content of /etc/group file -->
+  <ind:textfilecontent54_object id="object_account_unique_gid_get" version="1">
+    <ind:filepath>/etc/group</ind:filepath>
+    <!-- Group ID (GID) from /etc/group (3-rd column) captured as subexpression of this object -->
+    <ind:pattern operation="pattern match">^.*:x:([0-9]+):</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <!-- OVAL variable to hold the count of all the GID defined in /etc/group
+       (including duplicate entries if any) -->
+  <local_variable id="variable_count_of_all_gid_from_etc_group" datatype="int" version="1"
+  comment="Count of all GID rows retrieved from /etc/group (including duplicates if any)">
+    <count>
+      <object_component item_field="subexpression" object_ref="object_account_unique_gid_get" />
+    </count>
+  </local_variable>
+
+  <!-- Turn the OVAL variable representing count of gids into OVAL object
+       (for use in <variable_test> below)-->
+  <ind:variable_object id="object_count_of_all_gid_from_etc_group" version="1">
+    <ind:var_ref>variable_count_of_all_gid_from_etc_group</ind:var_ref>
+  </ind:variable_object>
+
+  <!-- OVAL variable to hold the count of unique gids defined in /etc/group -->
+  <local_variable id="variable_count_of_unique_gid_from_etc_group" datatype="int" version="1"
+  comment="Count of unique gid rows retrieved from /etc/group">
+    <count>
+      <unique>
+        <object_component item_field="subexpression" object_ref="object_account_unique_gid_get" />
+      </unique>
+    </count>
+  </local_variable>
+
+  <!-- Create OVAL state from count of unique usernames OVAL variable (to be used in
+       <variable_test> below -->
+  <ind:variable_state id="state_etc_group_no_duplicate_gid" version="1">
+    <ind:value var_ref="variable_count_of_unique_gid_from_etc_group" datatype="int"
+    operation="equals" var_check="at least one" />
+  </ind:variable_state>
+
+  <!-- Check if count of all the different usernames defined in /etc/group matches the count
+       of all unique usernames defined in /etc/group (IOW if there aren't duplicate entries) -->
+  <ind:variable_test id="test_etc_group_no_duplicate_gid" check="all" check_existence="all_exist"
+  comment="There should not exist duplicate gid entries in /etc/group" version="1">
+    <ind:object object_ref="object_count_of_all_gid_from_etc_group" />
+    <ind:state state_ref="state_etc_group_no_duplicate_gid" />
+  </ind:variable_test>
+
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_unique_gid/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_unique_gid/oval/shared.xml
@@ -1,12 +1,12 @@
 <def-group>
   <definition class="compliance" id="account_unique_gid" version="1">
     <metadata>
-      <title>Set All Accounts To Have Unique GIDs</title>
+      <title>Set All Groups To Have Unique GIDs</title>
       <affected family="unix">
         <platform>multi_platform_all</platform>
         <platform>multi_platform_sle</platform>
       </affected>
-      <description>All accounts on the system should have unique GIDs for proper accountability.</description>
+      <description>All groups on the system should have unique GIDs for proper accountability.</description>
     </metadata>
 
       <criteria comment="There should not exist duplicate gids entries in /etc/group">

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_unique_gid/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_unique_gid/rule.yml
@@ -1,0 +1,18 @@
+documentation_complete: true
+
+prodtype: multi_platform_sle,sle11,sle12
+
+title: 'Ensure All Accounts on the System Have Unique GIDs'
+
+description: 'Change GIDs, or delete accounts, so each has a unique name.'
+
+rationale: 'Unique GIDs allow for accountability on the system.'
+
+severity: medium
+
+ocil_clause: 'a line is returned'
+
+ocil: |-
+    Run the following command to check for duplicate account GIDs:
+    <pre>$ sudo pwck -qr</pre>
+    If there are no duplicate GIDs, no line will be returned.

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_unique_gid/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_unique_gid/rule.yml
@@ -2,9 +2,9 @@ documentation_complete: true
 
 prodtype: multi_platform_sle,sle11,sle12
 
-title: 'Ensure All Accounts on the System Have Unique GIDs'
+title: 'Ensure All groups on the System Have Unique GIDs'
 
-description: 'Change GIDs, or delete accounts, so each has a unique name.'
+description: 'Change GIDs, or delete groups, so each has a unique name.'
 
 rationale: 'Unique GIDs allow for accountability on the system.'
 

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -1,9 +1,0 @@
-documentation_complete: true
-
-title: 'prueba'
-
-description: |- 
-    Write the profile description here
-
-selections:
-    - account_unique_gid

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -6,19 +6,4 @@ description: |-
     Write the profile description here
 
 selections:
-    - file_owner_grub2_cfg
-    - file_groupowner_grub2_cfg
-    - disable_users_coredumps
-    - sysctl_fs_suid_dumpable
-    - sysctl_net_ipv6_conf_all_disable_ipv6
-    - audit_rules_kernel_module_loading
-    - audit_rules_kernel_module_loading_delete
-    - audit_rules_kernel_module_loading_finit
-    - audit_rules_kernel_module_loading_init
-    - file_owner_sshd_config
-    - file_groupowner_sshd_config
-    - file_permissions_sshd_config
-    - file_permissions_etc_passwd
-    - file_permissions_etc_shadow
-    - file_permissions_etc_group
-    - file_permissions_etc_gshadow
+    - account_unique_gid


### PR DESCRIPTION
#### Description:

- All accounts on the system should have unique GIDs for proper accountability.

#### Rationale:

- All accounts on the system should have unique GIDs for proper accountability.


