### PR TITLE
Regla no_plus_entries_passwd creada con check y fix

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/no_plus_entries_passwd/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/no_plus_entries_passwd/ansible/shared.yml
@@ -1,0 +1,11 @@
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_rhv,multi_platform_sle
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+- name: Delete "+:" entries in passwd
+  lineinfile:
+    path: /etc/passwd
+    state: absent
+    regexp: '^\+:'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/no_plus_entries_passwd/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/no_plus_entries_passwd/oval/shared.xml
@@ -1,0 +1,27 @@
+<def-group>
+  <definition class="compliance" id="no_plus_entries_passwd" version="1">
+    <metadata>
+      <title>No "+" entries in passwd</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>No "+" entries in passwd</description>
+    </metadata>
+    <criteria comment="No + entries in passwd">
+      <criterion comment="No + entries in passwd"
+        test_ref="test_no_plus_entries_passwd" /> 
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="none_exist"
+  comment="No + entries in passwd" id="test_no_plus_entries_passwd" version="1">
+    <ind:object object_ref="object_no_plus_entries_passwd" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_no_plus_entries_passwd" version="2">
+    <ind:filepath>/etc/passwd</ind:filepath>
+    <ind:pattern operation="pattern match">^\+:</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/no_plus_entries_passwd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/no_plus_entries_passwd/rule.yml
@@ -1,0 +1,24 @@
+documentation_complete: true
+
+prodtype: multi_platform_sle,sle11,sle12
+
+title: 'No plus entries in /etc/passwd'
+
+description: 'El carácter + en varios archivos solía ser marcadores para que los sistemas insertaran datos de
+mapas NIS en cierto punto en un archivo de configuración del sistema. Estas entradas ya no son
+necesarias en la mayoría de los sistemas, pero pueden existir en archivos que se han importado
+de otras plataformas.'
+
+rationale: 'El carácter + en varios archivos solía ser marcadores para que los sistemas insertaran datos de
+mapas NIS en cierto punto en un archivo de configuración del sistema. Estas entradas ya no son
+necesarias en la mayoría de los sistemas, pero pueden existir en archivos que se han importado
+de otras plataformas.'
+
+severity: medium
+
+ocil_clause: 'a line is returned'
+
+ocil: |-
+    Run the following command:
+    <pre>$ grep '^\+:' /etc/passwd</pre>
+    If there are no + entries, no line will be returned.

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -6,19 +6,4 @@ description: |-
     Write the profile description here
 
 selections:
-    - file_owner_grub2_cfg
-    - file_groupowner_grub2_cfg
-    - disable_users_coredumps
-    - sysctl_fs_suid_dumpable
-    - sysctl_net_ipv6_conf_all_disable_ipv6
-    - audit_rules_kernel_module_loading
-    - audit_rules_kernel_module_loading_delete
-    - audit_rules_kernel_module_loading_finit
-    - audit_rules_kernel_module_loading_init
-    - file_owner_sshd_config
-    - file_groupowner_sshd_config
-    - file_permissions_sshd_config
-    - file_permissions_etc_passwd
-    - file_permissions_etc_shadow
-    - file_permissions_etc_group
-    - file_permissions_etc_gshadow
+    - no_plus_entries_passwd

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -1,9 +1,0 @@
-documentation_complete: true
-
-title: 'prueba'
-
-description: |- 
-    Write the profile description here
-
-selections:
-    - no_plus_entries_passwd


### PR DESCRIPTION
#### Description:

- Asegura que no existan entradas "+" heredadas en /etc/passwd.

#### Rationale:

- El carácter + en varios archivos solía ser marcadores para que los sistemas insertaran datos de
mapas NIS en cierto punto en un archivo de configuración del sistema. Estas entradas ya no son
necesarias en la mayoría de los sistemas, pero pueden existir en archivos que se han importado
de otras plataformas.


