### PR TITLE
Regla no_plus_entries_group creada con check y fix

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/no_plus_entries_group/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/no_plus_entries_group/ansible/shared.yml
@@ -1,0 +1,11 @@
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_rhv,multi_platform_sle
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+- name: Delete "+:" entries in group
+  lineinfile:
+    path: /etc/group
+    state: absent
+    regexp: '^\+:'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/no_plus_entries_group/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/no_plus_entries_group/oval/shared.xml
@@ -1,0 +1,27 @@
+<def-group>
+  <definition class="compliance" id="no_plus_entries_group" version="1">
+    <metadata>
+      <title>No "+" entries in group</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>No "+" entries in group</description>
+    </metadata>
+    <criteria comment="No + entries in group">
+      <criterion comment="No + entries in group"
+        test_ref="test_no_plus_entries_group" /> 
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="none_exist"
+  comment="No + entries in group" id="test_no_plus_entries_group" version="1">
+    <ind:object object_ref="object_no_plus_entries_group" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_no_plus_entries_group" version="2">
+    <ind:filepath>/etc/group</ind:filepath>
+    <ind:pattern operation="pattern match">^\+:</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/no_plus_entries_group/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/no_plus_entries_group/rule.yml
@@ -1,0 +1,24 @@
+documentation_complete: true
+
+prodtype: multi_platform_sle,sle11,sle12
+
+title: 'No plus entries in /etc/group'
+
+description: 'El carácter + en varios archivos solía ser marcadores para que los sistemas insertaran datos de
+mapas NIS en cierto punto en un archivo de configuración del sistema. Estas entradas ya no son
+necesarias en la mayoría de los sistemas, pero pueden existir en archivos que se han importado
+de otras plataformas.'
+
+rationale: 'El carácter + en varios archivos solía ser marcadores para que los sistemas insertaran datos de
+mapas NIS en cierto punto en un archivo de configuración del sistema. Estas entradas ya no son
+necesarias en la mayoría de los sistemas, pero pueden existir en archivos que se han importado
+de otras plataformas.'
+
+severity: medium
+
+ocil_clause: 'a line is returned'
+
+ocil: |-
+    Run the following command:
+    <pre>$ grep '^\+:' /etc/group</pre>
+    If there are no + entries, no line will be returned.


### PR DESCRIPTION
#### Description:

- Asegura que no existan entradas "+" heredadas en /etc/group.

#### Rationale:

- El carácter + en varios archivos solía ser marcadores para que los sistemas insertaran datos de
mapas NIS en cierto punto en un archivo de configuración del sistema. Estas entradas ya no son
necesarias en la mayoría de los sistemas, pero pueden existir en archivos que se han importado
de otras plataformas.


