### PR TITLE
Regla no_plus_entries_shadow creada con check y fix

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/no_plus_entries_shadow/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/no_plus_entries_shadow/ansible/shared.yml
@@ -1,0 +1,11 @@
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_rhv,multi_platform_sle
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+- name: Delete "+:" entries in shadow
+  lineinfile:
+    path: /etc/shadow
+    state: absent
+    regexp: '^\+:'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/no_plus_entries_shadow/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/no_plus_entries_shadow/oval/shared.xml
@@ -1,0 +1,27 @@
+<def-shadow>
+  <definition class="compliance" id="no_plus_entries_shadow" version="1">
+    <metadata>
+      <title>No "+" entries in shadow</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>No "+" entries in shadow</description>
+    </metadata>
+    <criteria comment="No + entries in shadow">
+      <criterion comment="No + entries in shadow"
+        test_ref="test_no_plus_entries_shadow" /> 
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="none_exist"
+  comment="No + entries in shadow" id="test_no_plus_entries_shadow" version="1">
+    <ind:object object_ref="object_no_plus_entries_shadow" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_no_plus_entries_shadow" version="2">
+    <ind:filepath>/etc/shadow</ind:filepath>
+    <ind:pattern operation="pattern match">^\+:</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-shadow>

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/no_plus_entries_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/no_plus_entries_shadow/rule.yml
@@ -1,0 +1,24 @@
+documentation_complete: true
+
+prodtype: multi_platform_sle,sle11,sle12
+
+title: 'No plus entries in /etc/shadow'
+
+description: 'El carácter + en varios archivos solía ser marcadores para que los sistemas insertaran datos de
+mapas NIS en cierto punto en un archivo de configuración del sistema. Estas entradas ya no son
+necesarias en la mayoría de los sistemas, pero pueden existir en archivos que se han importado
+de otras plataformas.'
+
+rationale: 'El carácter + en varios archivos solía ser marcadores para que los sistemas insertaran datos de
+mapas NIS en cierto punto en un archivo de configuración del sistema. Estas entradas ya no son
+necesarias en la mayoría de los sistemas, pero pueden existir en archivos que se han importado
+de otras plataformas.'
+
+severity: medium
+
+ocil_clause: 'a line is returned'
+
+ocil: |-
+    Run the following command:
+    <pre>$ grep '^\+:' /etc/shadow</pre>
+    If there are no + entries, no line will be returned.


### PR DESCRIPTION
#### Description:

- Asegura que no existan entradas "+" heredadas en /etc/shadow

#### Rationale:

- El carácter + en varios archivos solía ser marcadores para que los sistemas insertaran datos de
mapas NIS en cierto punto en un archivo de configuración del sistema. Estas entradas ya no son
necesarias en la mayoría de los sistemas, pero pueden existir en archivos que se han importado
de otras plataformas.

