### PR TITLE
Regla write_permissions_user_hidden_files creada con check OVAL y fix

### DIFF
--- a/linux_os/guide/system/permissions/files/write_permissions_user_hidden_files/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/write_permissions_user_hidden_files/ansible/shared.yml
@@ -4,14 +4,11 @@
 # complexity = low
 # disruption = low
 
-- name: Get local paths
-  shell: find /home/* -type f \( -perm -g+w -or -perm -o+w \) -iname ".*"
-  register: hiddenfilepaths
-  ignore_errors: True
 
-- name: Change perms
-  file:
-    path: '{{ item }}'
-    mode: g-w,o-w
-  with_items:
-    - '{{ hiddenfilepaths.stdout_lines }}'
+- name: Get users home directories
+  shell: awk -F":" '$7!="/usr/sbin/nologin"&&$7!="/sbin/nologin"&&$3>999&&$6~"\\/.*" {print $6}' /etc/passwd
+  register: getUserHomePaths
+
+- name: Recursively find hidden files in user home directories and change their permisions
+  shell: find {{ item }} -name ".*" | xargs chmod o-w,g-w
+  with_items: "{{ getUserHomePaths.stdout_lines }}"

--- a/linux_os/guide/system/permissions/files/write_permissions_user_hidden_files/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/write_permissions_user_hidden_files/ansible/shared.yml
@@ -1,0 +1,17 @@
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_rhv,multi_platform_sle
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+- name: Get local paths
+  shell: find /home/* -type f \( -perm -g+w -or -perm -o+w \) -iname ".*"
+  register: hiddenfilepaths
+  ignore_errors: True
+
+- name: Change perms
+  file:
+    path: '{{ item }}'
+    mode: g-w,o-w
+  with_items:
+    - '{{ hiddenfilepaths.stdout_lines }}'

--- a/linux_os/guide/system/permissions/files/write_permissions_user_hidden_files/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/write_permissions_user_hidden_files/oval/shared.xml
@@ -1,0 +1,35 @@
+<def-group>
+  <definition class="compliance" id="write_permissions_user_hidden_files" version="1">
+    <metadata>
+      <title>Ensure user hidden files are not world-witable or group-writable</title>
+      <affected family="unix">
+        <platform>multi_platform_ol</platform>
+        <platform>multi_platform_opensuse</platform>
+        <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_sle</platform>
+        <platform>multi_platform_wrlinux</platform>
+      </affected>
+      <description>Ensure user hidden files are not world-witable or group-writable.</description>
+    </metadata>
+    <criteria>
+      <criterion test_ref="test_write_permissions_user_hidden_files" />
+    </criteria>
+  </definition>
+
+    <unix:file_test check="all" check_existence="none_exist" comment="Ensure user hidden files are not world-witable or group-writable" id="test_write_permissions_user_hidden_files" version="1">
+    <unix:object object_ref="object_write_permissions_user_hidden_files" />
+  </unix:file_test>
+
+  <unix:file_object comment="Ensure user hidden files are not world-witable or group-writable" id="object_write_permissions_user_hidden_files" version="1">
+    <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1" recurse_file_system="all" />
+    <unix:path operation="equals">/home</unix:path>
+    <unix:filename operation="pattern match">^[.].*</unix:filename>
+    <filter action="include">state_write_permissions_user_hidden_files</filter>
+  </unix:file_object>
+
+  <unix:file_state id="state_write_permissions_user_hidden_files" version="1" operator="OR">
+    <unix:gwrite datatype="boolean">true</unix:gwrite>
+    <unix:owrite datatype="boolean">true</unix:owrite>
+  </unix:file_state>
+
+</def-group>

--- a/linux_os/guide/system/permissions/files/write_permissions_user_hidden_files/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/write_permissions_user_hidden_files/oval/shared.xml
@@ -16,18 +16,35 @@
     </criteria>
   </definition>
 
-    <unix:file_test check="all" check_existence="none_exist" comment="Ensure user hidden files are not world-witable or group-writable" id="test_write_permissions_user_hidden_files" version="1">
-    <unix:object object_ref="object_write_permissions_user_hidden_files" />
+  <unix:file_test check="all" check_existence="none_exist" comment="/var/log/audit files mode 0600" id="test_write_permissions_user_hidden_files" version="1">
+    <unix:object object_ref="object_file_permissions_home_dir_get_directories_defined_in_passwd" />
   </unix:file_test>
 
-  <unix:file_object comment="Ensure user hidden files are not world-witable or group-writable" id="object_write_permissions_user_hidden_files" version="1">
-    <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1" recurse_file_system="all" />
-    <unix:path operation="equals">/home</unix:path>
+    <!-- OVAL object to collect content of /etc/passwd file -->
+  <ind:textfilecontent54_object id="object_write_permissions_user_hidden_files_get_home_dirs" version="1">
+    <ind:filepath>/etc/passwd</ind:filepath>
+    <!-- interactive users home path with shell!=nologin from /etc/passwd (6th column) captured as subexpression of this object -->
+    <ind:pattern operation="pattern match">.*:x:[0-9]{4,}:[0-9]+:.*:(.*):(?!.*nologin)</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <!-- OVAL variable to hold all the different paths from /etc/passwd -->
+  <local_variable id="var_write_permissions_user_hidden_files_get_home_dirs" comment="Paths from /etc/passwd" datatype="string" version="1">
+    <object_component item_field="subexpression" object_ref="object_write_permissions_user_hidden_files_get_home_dirs" />
+  </local_variable>
+
+  <unix:file_object comment="Directories that exist and are defined in passwd" id="object_file_permissions_home_dir_get_directories_defined_in_passwd" version="1">
+    <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1" recurse_file_system="local" />
+    <unix:path var_ref="var_write_permissions_user_hidden_files_get_home_dirs" var_check="at least one" />
     <unix:filename operation="pattern match">^[.].*</unix:filename>
-    <filter action="include">state_write_permissions_user_hidden_files</filter>
+    <filter action="include">state_write_permissions_user_hidden_files_permissions</filter>
+    <!-- don't search /proc, /sys, and some special files from /selinux -->
+    <filter action="exclude">state_file_permissions_unauthorized_world_write_exclude_special_selinux_files</filter>
+    <filter action="exclude">state_file_permissions_unauthorized_world_write_exclude_proc</filter>
+    <filter action="exclude">state_file_permissions_unauthorized_world_write_exclude_sys</filter>
   </unix:file_object>
 
-  <unix:file_state id="state_write_permissions_user_hidden_files" version="1" operator="OR">
+  <unix:file_state id="state_write_permissions_user_hidden_files_permissions" version="1" operator="OR">
     <unix:gwrite datatype="boolean">true</unix:gwrite>
     <unix:owrite datatype="boolean">true</unix:owrite>
   </unix:file_state>

--- a/linux_os/guide/system/permissions/files/write_permissions_user_hidden_files/rule.yml
+++ b/linux_os/guide/system/permissions/files/write_permissions_user_hidden_files/rule.yml
@@ -1,0 +1,21 @@
+documentation_complete: true
+
+prodtype: multi_platform_sle,sle11,sle12
+
+title: 'Ensure user hidden files are not world-witable or group-writable'
+
+description: |-
+    It is generally a good idea to remove global (other) and group write
+    access to the users hidden files.
+
+rationale: |-
+    It is generally a good idea to remove global (other) and group write
+    access to the users hidden files.
+
+severity: medium
+
+ocil_clause: 'there is output'
+
+ocil: |-
+    To find world-writable files, run the following command:
+    <pre>$ sudo find / -xdev -type f -perm -002</pre>

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -1,9 +1,0 @@
-documentation_complete: true
-
-title: 'prueba'
-
-description: |- 
-    Write the profile description here
-
-selections:
-    - write_permissions_user_hidden_files

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -6,19 +6,4 @@ description: |-
     Write the profile description here
 
 selections:
-    - file_owner_grub2_cfg
-    - file_groupowner_grub2_cfg
-    - disable_users_coredumps
-    - sysctl_fs_suid_dumpable
-    - sysctl_net_ipv6_conf_all_disable_ipv6
-    - audit_rules_kernel_module_loading
-    - audit_rules_kernel_module_loading_delete
-    - audit_rules_kernel_module_loading_finit
-    - audit_rules_kernel_module_loading_init
-    - file_owner_sshd_config
-    - file_groupowner_sshd_config
-    - file_permissions_sshd_config
-    - file_permissions_etc_passwd
-    - file_permissions_etc_shadow
-    - file_permissions_etc_group
-    - file_permissions_etc_gshadow
+    - write_permissions_user_hidden_files


### PR DESCRIPTION
#### Description:

- Ensure user hidden files are not world-witable or group-writable.

#### Rationale:

- Si bien el administrador del sistema puede establecer permisos seguros para los archivos "punto"
de los usuarios, los usuarios pueden anularlos fácilmente.

