### PR TITLE
Regla empty_group_shadow creada con check OVAL y fix

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/empty_group_shadow/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/empty_group_shadow/ansible/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_rhv,multi_platform_sle
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+- name: Get users of shadow group
+  shell: grep shadow /etc/group | cut -d":" -f4 | tr "," "\n"
+  register: shadowusers
+
+- name: Change perms
+  shell: gpasswd -d {{ item }} shadow
+  with_items:
+    - '{{ shadowusers.stdout_lines }}' 

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/empty_group_shadow/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/empty_group_shadow/oval/shared.xml
@@ -1,0 +1,23 @@
+<def-group>
+  <definition class="compliance" id="empty_group_shadow" version="1">
+    <metadata>
+      <title>Verify shadow group is empty</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+        <platform>multi_platform_sle</platform>
+      </affected>
+      <description>Verify shadow group is empty</description>
+    </metadata>
+    <criteria>
+      <criterion comment="Verify shadow group is empty" test_ref="test_empty_group_shadow" />
+    </criteria>
+  </definition>
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="Verify shadow group is empty" id="test_empty_group_shadow" version="1">
+    <ind:object object_ref="object_empty_group_shadow" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_empty_group_shadow" version="1">
+    <ind:filepath>/etc/group</ind:filepath>
+    <ind:pattern operation="pattern match">^shadow\:.*\:.*\:$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/empty_group_shadow/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/empty_group_shadow/rule.yml
@@ -1,0 +1,18 @@
+documentation_complete: true
+
+prodtype: multi_platform_sle,sle11,sle12
+
+title: 'Verify shadow group is empty'
+
+description: 'Verify shadow group is empty'
+
+rationale: 'Verify shadow group is empty'
+
+severity: high
+
+ocil_clause: 'a line is returned'
+
+ocil: |-
+    Run the following command:
+    <pre>$ sudo grep shadow /etc/group | cut -d -f4 | tr "," "\n"</pre>
+    no line will be returned.

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -6,19 +6,4 @@ description: |-
     Write the profile description here
 
 selections:
-    - file_owner_grub2_cfg
-    - file_groupowner_grub2_cfg
-    - disable_users_coredumps
-    - sysctl_fs_suid_dumpable
-    - sysctl_net_ipv6_conf_all_disable_ipv6
-    - audit_rules_kernel_module_loading
-    - audit_rules_kernel_module_loading_delete
-    - audit_rules_kernel_module_loading_finit
-    - audit_rules_kernel_module_loading_init
-    - file_owner_sshd_config
-    - file_groupowner_sshd_config
-    - file_permissions_sshd_config
-    - file_permissions_etc_passwd
-    - file_permissions_etc_shadow
-    - file_permissions_etc_group
-    - file_permissions_etc_gshadow
+    - empty_group_shadow

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -1,9 +1,0 @@
-documentation_complete: true
-
-title: 'prueba'
-
-description: |- 
-    Write the profile description here
-
-selections:
-    - empty_group_shadow


### PR DESCRIPTION
#### Description:

- Comprueba que el grupo "shadow" esté vacio.

#### Rationale:

- El grupo shadow permite que los programas del sistema que requieren acceso tengan la
capacidad de leer el archivo /etc/shadow. No se deben asignar usuarios al grupo de shadow.


