### PR TITLE
Regla package_xorg_x11_server_removed creada con check OVAL y fix

### DIFF
--- a/linux_os/guide/services/xwindows/disabling_xwindows/package_xorg_x11_server_removed/ansible/shared.yml
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/package_xorg_x11_server_removed/ansible/shared.yml
@@ -1,0 +1,16 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = disable
+# complexity = low
+# disruption = low
+- name: Ensure xorg-x11-server is removed
+  package:
+    name: xorg-x11-server
+    state: absent
+  tags:
+    - package_xorg_x11_server_removed
+    - high_severity
+    - disable_strategy
+    - low_complexity
+    - low_disruption
+    - no_reboot_needed

--- a/linux_os/guide/services/xwindows/disabling_xwindows/package_xorg_x11_server_removed/oval/shared.xml
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/package_xorg_x11_server_removed/oval/shared.xml
@@ -1,0 +1,26 @@
+<def-group>
+  <definition class="compliance" id="package_xorg_x11_server_removed"
+  version="1">
+    <metadata>
+      <title>Package xorg-x11-server Removed</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>The RPM package xorg-x11-server should be removed.</description>
+    </metadata>
+    <criteria>
+      <criterion comment="package xorg-x11-server is removed"
+      test_ref="test_package_xorg_x11_server_removed" />
+    </criteria>
+  </definition>
+
+  <linux:rpminfo_test check="all" check_existence="none_exist"
+  id="test_package_xorg_x11_server_removed" version="1"
+  comment="package xorg-x11-server is removed">
+    <linux:object object_ref="obj_package_xorg_x11_server_removed" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_object id="obj_package_xorg_x11_server_removed" version="1">
+    <linux:name>xorg-x11-server</linux:name>
+  </linux:rpminfo_object>
+
+</def-group>

--- a/linux_os/guide/services/xwindows/disabling_xwindows/package_xorg_x11_server_removed/rule.yml
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/package_xorg_x11_server_removed/rule.yml
@@ -1,0 +1,21 @@
+documentation_complete: true
+
+prodtype: multi_platform_sle,sle11,sle12
+
+title: 'Ensure package xorg-x11-server is uninstaled'
+
+description: 'Unless rquired, package xorg-x11-server should be uninstalled'
+
+rationale: 'El sistema X Window proporciona una interfaz gráfica de usuario (GUI) donde los usuarios
+pueden tener múltiples ventanas para ejecutar programas y varios complementos. El sistema X
+Windows generalmente se usa en estaciones de trabajo donde los usuarios inician sesión, pero
+no en servidores donde los usuarios generalmente no inician sesión.'
+
+severity: high
+
+ocil_clause: 'a line is returned'
+
+ocil: |-
+    Run the following command:
+    <pre>$ sudo rpm -qa | grep xorg-x11-server</pre>
+    No line will be returned.

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -6,19 +6,4 @@ description: |-
     Write the profile description here
 
 selections:
-    - file_owner_grub2_cfg
-    - file_groupowner_grub2_cfg
-    - disable_users_coredumps
-    - sysctl_fs_suid_dumpable
-    - sysctl_net_ipv6_conf_all_disable_ipv6
-    - audit_rules_kernel_module_loading
-    - audit_rules_kernel_module_loading_delete
-    - audit_rules_kernel_module_loading_finit
-    - audit_rules_kernel_module_loading_init
-    - file_owner_sshd_config
-    - file_groupowner_sshd_config
-    - file_permissions_sshd_config
-    - file_permissions_etc_passwd
-    - file_permissions_etc_shadow
-    - file_permissions_etc_group
-    - file_permissions_etc_gshadow
+    - package_xorg_x11_server_removed

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -1,9 +1,0 @@
-documentation_complete: true
-
-title: 'prueba'
-
-description: |- 
-    Write the profile description here
-
-selections:
-    - package_xorg_x11_server_removed


### PR DESCRIPTION
#### Description:

- Asegúrese de que el paquete xorg-x11-server no esta presente en el sistema.

#### Rationale:

- El sistema X Window proporciona una interfaz gráfica de usuario (GUI) donde los usuarios
pueden tener múltiples ventanas para ejecutar programas y varios complementos. El sistema X
Windows generalmente se usa en estaciones de trabajo donde los usuarios inician sesión, pero
no en servidores donde los usuarios generalmente no inician sesión.
