### PR TITLE
Regla package_openldap2-client_removed creada con check OVAL y fix

### DIFF
--- a/linux_os/guide/services/ldap/openldap_client/package_openldap2-client_removed/ansible/shared.yml
+++ b/linux_os/guide/services/ldap/openldap_client/package_openldap2-client_removed/ansible/shared.yml
@@ -1,0 +1,16 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = disable
+# complexity = low
+# disruption = low
+- name: Ensure openldap2-client is removed
+  package:
+    name: openldap2-client
+    state: absent
+  tags:
+    - package_xorg_x11_server_removed
+    - high_severity
+    - disable_strategy
+    - low_complexity
+    - low_disruption
+    - no_reboot_needed

--- a/linux_os/guide/services/ldap/openldap_client/package_openldap2-client_removed/oval/shared.xml
+++ b/linux_os/guide/services/ldap/openldap_client/package_openldap2-client_removed/oval/shared.xml
@@ -1,0 +1,26 @@
+<def-group>
+  <definition class="compliance" id="package_openldap2-client_removed"
+  version="1">
+    <metadata>
+      <title>Package openldap2-client Removed</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>The RPM package openldap2-client should be removed.</description>
+    </metadata>
+    <criteria>
+      <criterion comment="package openldap2-client is removed"
+      test_ref="test_package_openldap2-client_removed" />
+    </criteria>
+  </definition>
+
+  <linux:rpminfo_test check="all" check_existence="none_exist"
+  id="test_package_openldap2-client_removed" version="1"
+  comment="package openldap2-client is removed">
+    <linux:object object_ref="obj_package_openldap2-client_removed" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_object id="obj_package_openldap2-client_removed" version="1">
+    <linux:name>openldap2-client</linux:name>
+  </linux:rpminfo_object>
+
+</def-group>

--- a/linux_os/guide/services/ldap/openldap_client/package_openldap2-client_removed/rule.yml
+++ b/linux_os/guide/services/ldap/openldap_client/package_openldap2-client_removed/rule.yml
@@ -1,0 +1,20 @@
+documentation_complete: true
+
+prodtype: multi_platform_sle,sle11,sle12
+
+title: 'Ensure package openldap2-client is uninstaled'
+
+description: 'Unless required, package openldap2-client should be uninstalled'
+
+rationale: 'El Protocolo ligero de acceso a directorios (LDAP) se introdujo como reemplazo de NIS / YP.
+Es un servicio que proporciona un método para buscar información de una base de datos
+central.'
+
+severity: high
+
+ocil_clause: 'a line is returned'
+
+ocil: |-
+    Run the following command:
+    <pre>$ sudo rpm -qa | grep openldap2-client</pre>
+    No line will be returned.

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -6,19 +6,4 @@ description: |-
     Write the profile description here
 
 selections:
-    - file_owner_grub2_cfg
-    - file_groupowner_grub2_cfg
-    - disable_users_coredumps
-    - sysctl_fs_suid_dumpable
-    - sysctl_net_ipv6_conf_all_disable_ipv6
-    - audit_rules_kernel_module_loading
-    - audit_rules_kernel_module_loading_delete
-    - audit_rules_kernel_module_loading_finit
-    - audit_rules_kernel_module_loading_init
-    - file_owner_sshd_config
-    - file_groupowner_sshd_config
-    - file_permissions_sshd_config
-    - file_permissions_etc_passwd
-    - file_permissions_etc_shadow
-    - file_permissions_etc_group
-    - file_permissions_etc_gshadow
+    - package_openldap2-client_removed

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -1,9 +1,0 @@
-documentation_complete: true
-
-title: 'prueba'
-
-description: |- 
-    Write the profile description here
-
-selections:
-    - package_openldap2-client_removed


### PR DESCRIPTION
#### Description:

- Asegura que el paquete openldap2-client está desinstalado.

#### Rationale:

- El Protocolo ligero de acceso a directorios (LDAP) se introdujo como reemplazo de NIS / YP.
Es un servicio que proporciona un método para buscar información de una base de datos
central.
