### PR TITLE
Regla rsyslog_FileCreateMode creada con check OVAL y fix

### DIFF
--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_FileCreateMode/ansible/shared.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_FileCreateMode/ansible/shared.yml
@@ -1,0 +1,18 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+- name: Ensure FileCreateMode is set to 0640'
+  lineinfile:
+    path: /etc/rsyslog.conf
+    regexp: '\#?\$FileCreateMode.*'
+    line: $FileCreateMode 0640
+    state: present
+  register: rsyslog
+
+- name: Restart service rsyslog
+  service:
+    name: rsyslog
+    state: reloaded
+  when: rsyslog.changed

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_FileCreateMode/oval/shared.xml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_FileCreateMode/oval/shared.xml
@@ -1,0 +1,28 @@
+<def-group>
+  <definition class="compliance"
+  id="rsyslog_FileCreateMode" version="1">
+    <metadata>
+      <title>Ensure FileCreateMode is set to 0640</title>
+      <affected family="unix">
+        <platform>multi_platform_sle</platform>
+      </affected>
+      <description>Ensure FileCreateMode is set to 0640.</description>
+    </metadata>
+    <criteria>
+      <criterion comment="Ensure FileCreateMode is set to 0640 in /etc/rsyslog.conf"
+      test_ref="test_rsyslog_FileCreateMode" />
+    </criteria>
+  </definition>
+
+    <ind:textfilecontent54_test check="all" check_existence="all_exist"
+  comment="Ensure FileCreateMode is set to 0640 in /etc/rsyslog.conf" id="test_rsyslog_FileCreateMode" version="1">
+    <ind:object object_ref="object_rsyslog_FileCreateMode" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_rsyslog_FileCreateMode" version="2">
+    <ind:filepath>/etc/rsyslog.conf</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*(?i)\$FileCreateMode.0640$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_FileCreateMode/rule.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_FileCreateMode/rule.yml
@@ -1,0 +1,19 @@
+documentation_complete: true
+
+prodtype: sle11,sle12
+
+title: 'Ensure FileCreateMode is set to 0640'
+
+description: 'Ensure that the files created by rsyslog have 0640 as default permission mode.'
+
+rationale: 'rsyslog creará archivos de registro que aún no existen en el sistema. Esta configuración
+controla qué permisos se aplicarán a estos archivos recién creados.'
+
+severity: high
+
+ocil_clause: 'Ensure correct permissions'
+
+ocil: |-
+    Run the following command to check for correct configuration:
+    <pre>$ sudo grep "FileCreateMode" /etc/rsyslog.conf</pre>
+    Permissions should be 0640.


### PR DESCRIPTION
#### Description:

- Asegura que el valor de $FileCreateMode en /etc/rsyslog.com sea 0640.

#### Rationale:

- rsyslog creará archivos de registro que aún no existen en el sistema. Esta configuración
controla qué permisos se aplicarán a estos archivos recién creados.
