### PR TITLE
Regla root_gid_zero creada con check oval y fix

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/root_gid_zero/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/root_gid_zero/ansible/shared.yml
@@ -1,0 +1,8 @@
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_rhv,multi_platform_sle
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+- name: Change root GID to 0
+  shell: usermod -g 0 root

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/root_gid_zero/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/root_gid_zero/oval/shared.xml
@@ -1,0 +1,23 @@
+<def-group>
+  <definition class="compliance" id="root_gid_zero" version="1">
+    <metadata>
+      <title>Verify Root Has GID 0</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+        <platform>multi_platform_sle</platform>
+      </affected>
+      <description>Verify Root Has GID 0</description>
+    </metadata>
+    <criteria>
+      <criterion comment="Verify Root Has GID 0 in /etc/passwd" test_ref="test_root_gid_zero" />
+    </criteria>
+  </definition>
+  <ind:textfilecontent54_test check="all" check_existence="none_exist" comment="Verify Root Has GID 0 in /etc/passwd" id="test_root_gid_zero" version="1">
+    <ind:object object_ref="object_root_gid_zero" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_root_gid_zero" version="1">
+    <ind:filepath>/etc/passwd</ind:filepath>
+    <ind:pattern operation="pattern match">^root\:x\:0\:\b(?![0]\b)\d{1,20}\b\:.*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/root_gid_zero/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/root_gid_zero/rule.yml
@@ -1,0 +1,18 @@
+documentation_complete: true
+
+prodtype: fedora,ol7,ol8,rhel6,rhel7,rhel8,rhv4,sle11,sle12
+
+title: 'Ensure root GID is 0'
+
+description: |-
+    Ensure root GID is 0.
+
+rationale: |-
+    Ensure root GID is 0.
+
+severity: high
+
+ocil_clause: 'Root GID is not 0'
+
+ocil: |-
+    Ensure the root GID wirh the following command':' grep "^root:" /etc/passwd | cut -f4 -d, the output should be 0

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -1,9 +1,0 @@
-documentation_complete: true
-
-title: 'prueba'
-
-description: |- 
-    Write the profile description here
-
-selections:
-    - root_gid_zero

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -6,19 +6,4 @@ description: |-
     Write the profile description here
 
 selections:
-    - file_owner_grub2_cfg
-    - file_groupowner_grub2_cfg
-    - disable_users_coredumps
-    - sysctl_fs_suid_dumpable
-    - sysctl_net_ipv6_conf_all_disable_ipv6
-    - audit_rules_kernel_module_loading
-    - audit_rules_kernel_module_loading_delete
-    - audit_rules_kernel_module_loading_finit
-    - audit_rules_kernel_module_loading_init
-    - file_owner_sshd_config
-    - file_groupowner_sshd_config
-    - file_permissions_sshd_config
-    - file_permissions_etc_passwd
-    - file_permissions_etc_shadow
-    - file_permissions_etc_group
-    - file_permissions_etc_gshadow
+    - root_gid_zero


### PR DESCRIPTION
#### Description:

- Asegura que el GID de la cuenta root sea 0.

#### Rationale:

- El comando usermod se puede usar para especificar a qué grupo pertenece el usuario raíz.
Esto afecta los permisos de los archivos creados por el usuario root.

