### PR TITLE
Regla accounts_umask_etc_profile_d creada con check y fix

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile_d/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile_d/ansible/shared.yml
@@ -1,0 +1,17 @@
+# platform = multi_platform_all,multi_platform_sle
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+- (xccdf-var var_accounts_user_umask)
+
+- name: Get /etc/profile.d/*.sh files
+  shell: ls -a /etc/profile.d/*.sh
+  register: shFiles
+
+- name: Set user umask in /etc/profile
+  replace:
+      path: "{{  item  }}"
+      regexp: "umask.*"
+      replace: "umask {{ var_accounts_user_umask }}"
+  with_items: "{{ shFiles.stdout_lines }}"

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile_d/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile_d/oval/shared.xml
@@ -1,0 +1,30 @@
+<def-group>
+  <definition class="compliance" id="accounts_umask_etc_profile_d" version="2">
+    <metadata>
+      <title>Ensure that Users Have Sensible Umask Values in /etc/profile.d/*.sh</title>
+      <affected family="unix">
+        <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_sle</platform>
+        <platform>multi_platform_wrlinux</platform>
+      </affected>
+      <description>The default umask for all users should be set correctly</description>
+    </metadata>
+    <criteria operator="AND">
+      <criterion test_ref="tst_accounts_umask_etc_profile_d" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="none_exist" comment="test" id="tst_accounts_umask_etc_profile_d" version="2">
+    <ind:object object_ref="obj_accounts_umask_etc_profile_d" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_accounts_umask_etc_profile_d"
+  comment="Umask value from /etc/profile.d/*.sh" version="1">
+    <ind:behaviors recurse="directories" recurse_direction="down" max_depth="-1" recurse_file_system="local" />
+    <ind:path operation="equals">/etc/profile.d</ind:path>
+    <ind:filename operation="pattern match">^.*\.sh$</ind:filename>
+    <ind:pattern operation="pattern match">^[\s]*umask[\s]+(?!027)</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile_d/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile_d/rule.yml
@@ -1,0 +1,27 @@
+documentation_complete: true
+
+prodtype: multi_platform_sle,sle11,sle12
+
+title: 'Ensure the Default Umask is Set Correctly in /etc/profile.d/*.sh'
+
+description: |-
+    To ensure the default umask controlled by <tt>/etc/profile.d/</tt> is set properly,
+    add or correct the <tt>umask</tt> setting in <tt>/etc/profile</tt> to read as follows:
+    <pre>umask <sub idref="var_accounts_user_umask" /></pre>
+
+rationale: |-
+    The umask value influences the permissions assigned to files when they are created.
+    A misconfigured umask value could result in files with excessive permissions that can be read or
+    written to by unauthorized users.
+
+severity: high
+
+ocil_clause: 'the above command returns no output, or if the umask is configured incorrectly'
+
+ocil: |-
+    Verify the <tt>umask</tt> setting is configured correctly in the <tt>/etc/profile/*sh</tt> files by
+    running the following command:
+    <pre># grep "umask" /etc/profile.d/*sh</pre>
+    All output must show the value of <tt>umask</tt> set as shown in the below:
+    <pre># grep "umask" /etc/profile.d/*sh
+    umask <sub idref="var_accounts_user_umask" /></pre>

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -1,9 +1,0 @@
-documentation_complete: true
-
-title: 'prueba'
-
-description: |- 
-    Write the profile description here
-
-selections:
-    - accounts_umask_etc_profile_d

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -6,19 +6,4 @@ description: |-
     Write the profile description here
 
 selections:
-    - file_owner_grub2_cfg
-    - file_groupowner_grub2_cfg
-    - disable_users_coredumps
-    - sysctl_fs_suid_dumpable
-    - sysctl_net_ipv6_conf_all_disable_ipv6
-    - audit_rules_kernel_module_loading
-    - audit_rules_kernel_module_loading_delete
-    - audit_rules_kernel_module_loading_finit
-    - audit_rules_kernel_module_loading_init
-    - file_owner_sshd_config
-    - file_groupowner_sshd_config
-    - file_permissions_sshd_config
-    - file_permissions_etc_passwd
-    - file_permissions_etc_shadow
-    - file_permissions_etc_group
-    - file_permissions_etc_gshadow
+    - accounts_umask_etc_profile_d


### PR DESCRIPTION
#### Description:

- To ensure the default umask controlled by /etc/profile.d/*.sh is set properly, add or correct the umask setting in /etc/profile.d/*.sh to read as follows: umask 027

#### Rationale:

- The umask value influences the permissions assigned to files when they are created. A misconfigured umask value could result in files with excessive permissions that can be read or written to by unauthorized users.

