### PR TITLE
Fix creado para regla ntpd_specify_remote_server

### DIFF
--- a/linux_os/guide/services/ntp/ntpd_specify_remote_server/ansible/shared.yml
+++ b/linux_os/guide/services/ntp/ntpd_specify_remote_server/ansible/shared.yml
@@ -1,0 +1,19 @@
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+- (xccdf-var var_ntpd_remote_server)
+
+- name: Configure ntp remote server
+  lineinfile:
+    dest: /etc/ntp.conf
+    line: "server {{ var_ntpd_remote_server }}"
+    regexp: '^\s*server\s*.*$'
+    state: present
+    create: yes
+
+- name: Restart ntpd
+  service:
+    name: ntpd
+    state: restarted

--- a/linux_os/guide/services/ntp/ntpd_specify_remote_server/oval/shared.xml
+++ b/linux_os/guide/services/ntp/ntpd_specify_remote_server/oval/shared.xml
@@ -20,13 +20,20 @@
   comment="Ensure at least one ntpd NTP server is set" id="test_ntp_remote_server"
   version="1">
     <ind:object object_ref="obj_ntp_remote_server" />
+    <ind:state state_ref="state_ntp_remote_server" />
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object comment="Ensure at least one ntpd NTP server is set"
   id="obj_ntp_remote_server" version="1">
     <ind:filepath>/etc/ntp.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*server[\s]+.+$</ind:pattern>
+    <ind:pattern operation="pattern match">^[ ]*server[ ]+(.*)[ ]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_ntp_remote_server" version="1">
+    <ind:subexpression operation="equals" var_ref="var_ntpd_remote_server" />
+  </ind:textfilecontent54_state>
+
+  <external_variable comment="ntp remote server" datatype="string" id="var_ntpd_remote_server" version="1" />
 
 </def-group>

--- a/linux_os/guide/services/ntp/var_ntpd_remote_server.var
+++ b/linux_os/guide/services/ntp/var_ntpd_remote_server.var
@@ -1,0 +1,12 @@
+documentation_complete: true
+
+title: 'Remote ntp server'
+
+description: 'The remote ntp server'
+
+type: string
+
+interactive: false
+
+options:
+    default: 129.6.15.28

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -1,9 +1,0 @@
-documentation_complete: true
-
-title: 'prueba'
-
-description: |- 
-    Write the profile description here
-
-selections:
-    - ntpd_specify_remote_server

--- a/sle12/profiles/prueba.profile
+++ b/sle12/profiles/prueba.profile
@@ -6,19 +6,4 @@ description: |-
     Write the profile description here
 
 selections:
-    - file_owner_grub2_cfg
-    - file_groupowner_grub2_cfg
-    - disable_users_coredumps
-    - sysctl_fs_suid_dumpable
-    - sysctl_net_ipv6_conf_all_disable_ipv6
-    - audit_rules_kernel_module_loading
-    - audit_rules_kernel_module_loading_delete
-    - audit_rules_kernel_module_loading_finit
-    - audit_rules_kernel_module_loading_init
-    - file_owner_sshd_config
-    - file_groupowner_sshd_config
-    - file_permissions_sshd_config
-    - file_permissions_etc_passwd
-    - file_permissions_etc_shadow
-    - file_permissions_etc_group
-    - file_permissions_etc_gshadow
+    - ntpd_specify_remote_server


### PR DESCRIPTION
#### Description:

- Specify a Remote NTP Server

#### Rationale:

- Synchronizing with an NTP server makes it possible to collate system logs from multiple sources or correlate computer events with real time events.

- Hay que poner el servidor correcto en var_ntpd_specify_remote_server.var
