### PR TITLE
Ansible creado

### DIFF
--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/ansible/shared.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/ansible/shared.yml
@@ -1,0 +1,21 @@
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_rhv,multi_platform_sle
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+- name: Search for log files
+  shell: find /var/log -type f 2>/dev/null
+  args:
+    warn: False
+    executable: /bin/bash
+  check_mode: no
+  register: find_result
+  changed_when: false
+
+- name: Apply permissions
+  file:
+    path: "{{ item }}"
+    mode: g-wx,o-rwx
+  with_items:
+    - "{{ find_result.stdout_lines }}"


### PR DESCRIPTION
#### Description:

The file permissions for all log files written by <tt>rsyslog</tt> should
    be set to 600, or more restrictive. These log files are determined by the
    second part of each Rule line in <tt>/etc/rsyslog.conf</tt> and typically
    all appear in <tt>/var/log</tt>. For each log file <i>LOGFILE</i>
    referenced in <tt>/etc/rsyslog.conf</tt>, run the following command to
    inspect the file's permissions:
    <pre>$ ls -l <i>LOGFILE</i></pre>
    If the permissions are not 600 or more restrictive, run the following
    command to correct this:
    <pre>$ sudo chmod 0600 <i>LOGFILE</i></pre>

#### Rationale:

   Log files can contain valuable information regarding system
    configuration. If the system log files are not protected unauthorized
    users could change the logged data, eliminating their forensic value.
